### PR TITLE
fix include  problem

### DIFF
--- a/theta/include/theta_union.hpp
+++ b/theta/include/theta_union.hpp
@@ -24,7 +24,7 @@
 #include <functional>
 #include <climits>
 
-#include <theta_sketch.hpp>
+#include "theta_sketch.hpp"
 
 namespace datasketches {
 


### PR DESCRIPTION
Integrating DataSketches Theta into Apache Impala and  compile error：
/path/theta_union.hpp:27:10: fatal error: theta_sketch.hpp: No such file or directory
 #include <theta_sketch.hpp>