### PR TITLE
Matches the Theta interface of the Java implementation

### DIFF
--- a/theta/include/theta_union.hpp
+++ b/theta/include/theta_union.hpp
@@ -48,6 +48,95 @@ public:
   void update(const theta_sketch_alloc<A>& sketch);
 
   /**
+   * This method is to update the union with a given string.
+   * @param value string to update the union with
+   */
+  void update(const std::string &value);
+  
+  /**
+   * This method is to update the union with a given unsigned 64-bit integer.
+   * @param value uint64_t to update the union with
+   */
+  void update(uint64_t value);
+  
+  /**
+   * This method is to update the union with a given signed 64-bit integer.
+   * @param value int64_t to update the union with
+   */
+  void update(int64_t value);
+  
+  /**
+   * This method is to update the union with a given unsigned 32-bit integer.
+   * For compatibility with Java implementation.
+   * @param value uint32_t to update the union with
+   */
+  void update(uint32_t value);
+  
+  /**
+   * This method is to update the union with a given signed 32-bit integer.
+   * For compatibility with Java implementation.
+   * @param value int32_t to update the union with
+   */
+  void update(int32_t value);
+  
+  /**
+   * This method is to update the union with a given unsigned 16-bit integer.
+   * For compatibility with Java implementation.
+   * @param value uint16_t to update the union with
+   */
+  void update(uint16_t value);
+  
+  /**
+   * This method is to update the union with a given signed 16-bit integer.
+   * For compatibility with Java implementation.
+   * @param value int16_t to update the union with
+   */
+  void update(int16_t value);
+  
+  /**
+   * This method is to update the union with a given unsigned 8-bit integer.
+   * For compatibility with Java implementation.
+   * @param value uint8_t to update the union with
+   */
+  void update(uint8_t value);
+  
+  /**
+   * This method is to update the union with a given signed 8-bit integer.
+   * For compatibility with Java implementation.
+   * @param value int8_t to update the union with
+   */
+  void update(int8_t value);
+  
+  /**
+   * This method is to update the union with a given double-precision floating point value.
+   * For compatibility with Java implementation.
+   * @param value double to update the union with
+   */
+  void update(double value);
+  
+  /**
+   * This method is to update the union with a given floating point value.
+   * For compatibility with Java implementation.
+   * @param value float to update the union with
+   */
+  void update(float value);
+  
+  /**
+   * This method is to update the union with given data of any type.
+   * This is a "universal" update that covers all cases above,
+   * but may produce different hashes.
+   * Be very careful to hash input values consistently using the same approach
+   * both over time and on different platforms
+   * and while passing sketches between C++ environment and Java environment.
+   * Otherwise two sketches that should represent overlapping sets will be disjoint
+   * For instance, for signed 32-bit values call update(int32_t) method above,
+   * which does widening conversion to int64_t, if compatibility with Java is expected
+   * @param data pointer to the data
+   * @param length of the data in bytes
+   */
+  void update(const void *data, unsigned length);
+
+  /**
    * This method produces a copy of the current state of the union as a compact sketch.
    * @param ordered optional flag to specify if ordered sketch should be produced
    * @return the result of the union

--- a/theta/include/theta_union_impl.hpp
+++ b/theta/include/theta_union_impl.hpp
@@ -50,6 +50,79 @@ void theta_union_alloc<A>::update(const theta_sketch_alloc<A>& sketch) {
 }
 
 template<typename A>
+void theta_union_alloc<A>::update(const std::string &value) {
+    if (value.empty()) return;
+    is_empty_ = false;
+    state_.update(value);
+}
+
+template<typename A>
+void theta_union_alloc<A>::update(uint64_t value){
+    is_empty_ = false;
+    state_.update(value);
+}
+  
+template<typename A>
+void theta_union_alloc<A>::update(int64_t value){
+    is_empty_ = false;
+    state_.update(value);
+}
+  
+template<typename A>
+void theta_union_alloc<A>::update(uint32_t value){
+    is_empty_ = false;
+    state_.update(value);
+}
+  
+template<typename A>
+void theta_union_alloc<A>::update(int32_t value){
+    is_empty_ = false;
+    state_.update(value);
+}
+  
+template<typename A>
+void theta_union_alloc<A>::update(uint16_t value){
+    is_empty_ = false;
+    state_.update(value);
+}
+  
+template<typename A>
+void theta_union_alloc<A>::update(int16_t value){
+    is_empty_ = false;
+    state_.update(value);
+}
+  
+template<typename A>
+void theta_union_alloc<A>::update(uint8_t value){
+    is_empty_ = false;
+    state_.update(value);
+}
+  
+template<typename A>
+void theta_union_alloc<A>::update(int8_t value){
+    is_empty_ = false;
+    state_.update(value);
+}
+  
+template<typename A>
+void theta_union_alloc<A>::update(double value){
+    is_empty_ = false;
+    state_.update(value);
+}
+  
+template<typename A>
+void theta_union_alloc<A>::update(float value){
+    is_empty_ = false;
+    state_.update(value);
+}
+  
+template<typename A>
+void theta_union_alloc<A>::update(const void *data, unsigned length){
+    is_empty_ = false;
+    state_.update(data, length);
+}
+
+template<typename A>
 compact_theta_sketch_alloc<A> theta_union_alloc<A>::get_result(bool ordered) const {
   if (is_empty_) return state_.compact(ordered);
   const uint32_t nom_num_keys = 1 << state_.lg_nom_size_;

--- a/theta/test/theta_union_test.cpp
+++ b/theta/test/theta_union_test.cpp
@@ -50,6 +50,16 @@ TEST_CASE("theta union: non empty no retained keys", "[theta_union]") {
   REQUIRE(sketch.get_theta() == Approx(0.001).margin(1e-10));
 }
 
+TEST_CASE("theta union: single item", "[theta_union]") {
+  theta_union u = theta_union::builder().build();
+  u.update(1);
+  compact_theta_sketch sketch = u.get_result();
+  REQUIRE(sketch.get_num_retained() == 1);
+  REQUIRE_FALSE(sketch.is_empty());
+  REQUIRE_FALSE(sketch.is_estimation_mode());
+  REQUIRE(sketch.get_theta() == 1.0);
+}
+
 TEST_CASE("theta union: exact mode half overlap", "[theta_union]") {
   update_theta_sketch sketch1 = update_theta_sketch::builder().build();
   int value = 0;


### PR DESCRIPTION
I recently started integrating DataSketches Theta into Apache Impala and need to add matching methods in the Java implementation.
https://github.com/apache/datasketches-java/blob/master/src/main/java/org/apache/datasketches/theta/Union.java