### PR TITLE
Fix some CMake include file issues

### DIFF
--- a/hll/CMakeLists.txt
+++ b/hll/CMakeLists.txt
@@ -35,6 +35,7 @@ target_compile_features(hll INTERFACE cxx_std_11)
 # TODO: would be useful if this didn't need to be reproduced in target_sources(), too
 set(hll_HEADERS "")
 list(APPEND hll_HEADERS "include/hll.hpp;include/AuxHashMap.hpp;include/CompositeInterpolationXTable.hpp")
+list(APPEND hll_HEADERS "include/hll.private.hpp;include/HllSketchImplFactory.hpp")
 list(APPEND hll_HEADERS "include/CouponHashSet.hpp;include/CouponList.hpp")
 list(APPEND hll_HEADERS "include/CubicInterpolation.hpp;include/HarmonicNumbers.hpp;include/Hll4Array.hpp")
 list(APPEND hll_HEADERS "include/Hll6Array.hpp;include/Hll8Array.hpp;include/HllArray.hpp")
@@ -60,6 +61,7 @@ install(FILES ${hll_HEADERS}
 target_sources(hll
   INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/include/hll.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/hll.private.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/AuxHashMap.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/CompositeInterpolationXTable.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/CouponHashSet.hpp
@@ -71,6 +73,7 @@ target_sources(hll
     ${CMAKE_CURRENT_SOURCE_DIR}/include/Hll8Array.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/HllArray.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/HllSketchImpl.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/HllSketchImplFactory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/HllUtil.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/RelativeErrorTables.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/coupon_iterator.hpp

--- a/tuple/CMakeLists.txt
+++ b/tuple/CMakeLists.txt
@@ -53,7 +53,7 @@ list(APPEND tuple_HEADERS "include/bounds_on_ratios_in_sampled_sets.hpp")
 list(APPEND tuple_HEADERS "include/bounds_on_ratios_in_theta_sketched_sets.hpp")
 list(APPEND tuple_HEADERS "include/jaccard_similarity.hpp")
 list(APPEND tuple_HEADERS "include/theta_comparators.hpp")
-list(APPEND tuple_HEADERS "include/theta_cnstants.hpp")
+list(APPEND tuple_HEADERS "include/theta_constants.hpp")
 
 install(TARGETS tuple
   EXPORT ${PROJECT_NAME}


### PR DESCRIPTION
The changes in this pull request were necessary to build bryanherger/vertica-datasketch after I added Hll sketch type as a UDAF.