### PR TITLE
Publish 2.2.0b1 under whylabs-datasketches name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ Default/
 .eggs/
 .tox/
 dist/
-python/datasketches.egg-info/
+python/whylabs_datasketches.egg-info/
 
 # Log file
 
@@ -40,3 +40,8 @@ _*/
 
 # exceptions
 !__init__.py
+
+.idea
+
+cmake-build-debug
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM quay.io/pypa/manylinux2010_x86_64
+
+RUN yum update
+
+RUN mkdir /io
+WORKDIR /io
+
+COPY . .
+
+RUN ls python/ -alh
+RUN ./build_wheels.sh

--- a/build_wheels.sh
+++ b/build_wheels.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e -u -x
+
+PLAT=manylinux2010_x86_64
+
+function repair_wheel {
+    wheel="$1"
+    if ! auditwheel show "$wheel"; then
+        echo "Skipping non-platform wheel $wheel"
+    else
+        auditwheel repair "$wheel" --plat "$PLAT" -w dist/
+    fi
+}
+
+# Compile wheels
+for PYBIN in /opt/python/*/bin; do
+    "${PYBIN}/pip" install wheel
+    "${PYBIN}/pip" wheel . --no-deps -w dist/
+done
+
+# Bundle external shared libraries into the wheels
+for whl in dist/*.whl; do
+    repair_wheel "$whl"
+done

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,8 @@ class CMakeBuild(build_ext):
         cmake_args += ['-DWITH_PYTHON=True']
         cfg = 'Debug' if self.debug else 'Release'
         build_args = ['--config', cfg]
+        # Require to enable Pybind11 to pick up the correct Python paths
+        cmake_args += ['-DPYTHON_EXECUTABLE=' + sys.executable]
 
         if platform.system() == "Windows":
             cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(
@@ -76,8 +78,8 @@ class CMakeBuild(build_ext):
         print() # add an empty line to pretty print
 
 setup(
-    name='datasketches',
-    version='2.2.0-SNAPSHOT',
+    name='whylabs-datasketches',
+    version='2.2.0b1',
     author='Datasketches Developers',
     author_email='dev@datasketches.apache.org',
     description='A wrapper for the C++ Datasketches library',


### PR DESCRIPTION
Enable CMake to pick up the correct Python headers

This is to build the artifacts for publishing

For Mac OS-X, currently I'm manually publishing them with conda environment:


```
conda activate datasketches-3.[6,7,8,9] # different Python environments
pip wheel . --no-deps -w dist/
twine upload dist/*
```