### PR TITLE
Fix unused function compile issues

### DIFF
--- a/cpc/include/icon_estimator.hpp
+++ b/cpc/include/icon_estimator.hpp
@@ -231,7 +231,7 @@ static const double ICON_POLYNOMIAL_COEFFICIENTS[ICON_TABLE_SIZE] = {
 #endif
 };
 
-static double evaluate_polynomial(const double* coefficients, int start, int num, double x) {
+static inline double evaluate_polynomial(const double* coefficients, int start, int num, double x) {
   const int final = start + num - 1;
   double total = coefficients[final];
   for (int j = final - 1; j >= start; j--) {
@@ -241,11 +241,11 @@ static double evaluate_polynomial(const double* coefficients, int start, int num
   return total;
 }
 
-static double icon_exponential_approximation(double k, double c) {
+static inline double icon_exponential_approximation(double k, double c) {
   return (0.7940236163830469 * k * pow(2.0, c / k));
 }
 
-static double compute_icon_estimate(uint8_t lg_k, uint64_t c) {
+static inline double compute_icon_estimate(uint8_t lg_k, uint64_t c) {
   if (lg_k < ICON_MIN_LOG_K || lg_k > ICON_MAX_LOG_K) throw std::out_of_range("lg_k out of range");
   if (c < 2) return ((c == 0) ? 0.0 : 1.0);
   const size_t k = 1 << lg_k;


### PR DESCRIPTION
Integrating DataSketches CPC to Impala, when compiling with -ASan parameter, the following error is displayed:
...
In file included from /home/impdev/Impala/be/src/exprs/datasketches-common.cc:22:
In file included from /home/impdev/Impala/be/src/thirdparty/datasketches/cpc_sketch.hpp:309:
In file included from /home/impdev/Impala/be/src/thirdparty/datasketches/cpc_sketch_impl.hpp:32:
/home/impdev/Impala/be/src/thirdparty/datasketches/icon_estimator.hpp:248:15: error: unused function 'compute_icon_estimate' [-Werror,-Wunused-function]
static double compute_icon_estimate(uint8_t lg_k, uint64_t c) {
              ^
1 error generated.