### PR TITLE
single compute_seed_hash implementation

### DIFF
--- a/common/include/MurmurHash3.h
+++ b/common/include/MurmurHash3.h
@@ -3,6 +3,7 @@
 //  * Changed input seed in MurmurHash3_x64_128 to uint64_t
 //  * Define and use HashState reference to return result
 //  * Made entire hash function defined inline
+//  * Added compute_seed_hash
 //-----------------------------------------------------------------------------
 // MurmurHash3 was written by Austin Appleby, and is placed in the public
 // domain. The author hereby disclaims copyright to this source code.
@@ -169,5 +170,11 @@ FORCE_INLINE void MurmurHash3_x64_128(const void* key, int lenBytes, uint64_t se
 }
 
 //-----------------------------------------------------------------------------
+
+FORCE_INLINE uint16_t compute_seed_hash(uint64_t seed) {
+  HashState hashes;
+  MurmurHash3_x64_128(&seed, sizeof(seed), 0, hashes);
+  return static_cast<uint16_t>(hashes.h1 & 0xffff);
+}
 
 #endif // _MURMURHASH3_H_

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -15,6 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# two parts here, the common test code for other parts to use,
+# and an integration test using the other parts of the library.
+
+# common dependencies for tests
 add_library(common_test OBJECT "")
 
 set_target_properties(common_test PROPERTIES
@@ -35,4 +39,24 @@ target_sources(common_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/catch_runner.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_allocator.cpp
+)
+
+# now the integration test part
+add_executable(integration_test)
+
+target_link_libraries(integration_test cpc fi hll kll req sampling theta tuple common_test)
+
+set_target_properties(integration_test PROPERTIES
+  CXX_STANDARD 11
+  CXX_STANDARD_REQUIRED YES
+)
+
+add_test(
+  NAME integration_test
+  COMMAND integration_test
+)
+
+target_sources(integration_test
+  PRIVATE
+    integration_test.cpp
 )

--- a/common/test/integration_test.cpp
+++ b/common/test/integration_test.cpp
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <catch.hpp>
+
+#include "cpc_sketch.hpp"
+#include "cpc_union.hpp"
+#include "frequent_items_sketch.hpp"
+#include "hll.hpp"
+#include "kll_sketch.hpp"
+#include "req_sketch.hpp"
+#include "var_opt_sketch.hpp"
+#include "var_opt_union.hpp"
+#include "theta_sketch.hpp"
+#include "theta_union.hpp"
+#include "theta_intersection.hpp"
+#include "theta_a_not_b.hpp"
+#include "tuple_sketch.hpp"
+#include "tuple_union.hpp"
+#include "tuple_intersection.hpp"
+#include "tuple_a_not_b.hpp"
+
+namespace datasketches {
+
+template<typename Summary>
+struct subtracting_intersection_policy {
+  void operator()(Summary& summary, const Summary& other) const {
+    summary -= other;
+  }
+};
+
+using tuple_intersection_float = tuple_intersection<float, subtracting_intersection_policy<float>>;
+
+TEST_CASE("integration: declare all sketches", "[integration]") {
+  cpc_sketch cpc(12);
+  cpc_union cpc_u(12);
+
+  frequent_items_sketch<std::string> fi(100);
+
+  hll_sketch hll(13);
+  hll_union hll_u(13);
+
+  kll_sketch<double> kll(200);
+
+  req_sketch<double> req(12);
+
+  var_opt_sketch<std::string> vo(100);
+  var_opt_union<std::string> vo_u(100);
+
+  update_theta_sketch theta = update_theta_sketch::builder().build();
+  theta_union theta_u = theta_union::builder().build();
+  theta_intersection theta_i;
+  theta_a_not_b theta_anb;
+
+  auto tuple = update_tuple_sketch<float>::builder().build();
+  auto tuple_u = tuple_union<float>::builder().build();
+  tuple_intersection_float tuple_i;
+  tuple_a_not_b<float> tuple_anb;
+}
+
+} /* namespace datasketches */

--- a/cpc/include/cpc_util.hpp
+++ b/cpc/include/cpc_util.hpp
@@ -24,12 +24,6 @@
 
 namespace datasketches {
 
-static inline uint16_t compute_seed_hash(uint64_t seed) {
-  HashState hashes;
-  MurmurHash3_x64_128(&seed, sizeof(seed), 0, hashes);
-  return hashes.h1 & 0xffff;
-}
-
 static inline uint64_t divide_longs_rounding_up(uint64_t x, uint64_t y) {
   if (y == 0) throw std::invalid_argument("divide_longs_rounding_up: bad argument");
   const uint64_t quotient = x / y;

--- a/theta/include/theta_update_sketch_base.hpp
+++ b/theta/include/theta_update_sketch_base.hpp
@@ -185,12 +185,6 @@ static inline uint64_t compute_hash(const void* data, size_t length, uint64_t se
   return (hashes.h1 >> 1); // Java implementation does unsigned shift >>> to make values positive
 }
 
-static inline uint16_t compute_seed_hash(uint64_t seed) {
-  HashState hashes;
-  MurmurHash3_x64_128(&seed, sizeof(seed), 0, hashes);
-  return hashes.h1;
-}
-
 // iterators
 
 template<typename Entry, typename ExtractKey>


### PR DESCRIPTION
Fixes #199, although I don't know a clean way to have a test for it. It did work when I tried a local test.

Not sure if the definition belongs in Murmurhash3 or if common_defs is more appropriate? Happy to relocate as needed.