### PR TITLE
changed policy to return void

### DIFF
--- a/theta/include/theta_intersection.hpp
+++ b/theta/include/theta_intersection.hpp
@@ -33,13 +33,13 @@ public:
   using Sketch = theta_sketch_alloc<Allocator>;
   using CompactSketch = compact_theta_sketch_alloc<Allocator>;
 
-  struct pass_through_policy {
-    uint64_t operator()(uint64_t internal_entry, uint64_t incoming_entry) const {
+  struct nop_policy {
+    void operator()(uint64_t internal_entry, uint64_t incoming_entry) const {
       unused(incoming_entry);
-      return internal_entry;
+      unused(internal_entry);
     }
   };
-  using State = theta_intersection_base<Entry, ExtractKey, pass_through_policy, Sketch, CompactSketch, Allocator>;
+  using State = theta_intersection_base<Entry, ExtractKey, nop_policy, Sketch, CompactSketch, Allocator>;
 
   /*
    * Constructor

--- a/theta/include/theta_intersection_impl.hpp
+++ b/theta/include/theta_intersection_impl.hpp
@@ -24,7 +24,7 @@ namespace datasketches {
 
 template<typename A>
 theta_intersection_alloc<A>::theta_intersection_alloc(uint64_t seed, const A& allocator):
-state_(seed, pass_through_policy(), allocator)
+state_(seed, nop_policy(), allocator)
 {}
 
 template<typename A>


### PR DESCRIPTION
Some early development version of the intersection base expected a value from an intersection policy. At some point during development this was changed to void, but this policy in the Theta sketch still returns a value in a void context. It does not affect the result, but potentially is more costly and a bit confusing.