### PR TITLE
adjust python test tolerances

### DIFF
--- a/python/tests/kll_test.py
+++ b/python/tests/kll_test.py
@@ -30,10 +30,10 @@ class KllTest(unittest.TestCase):
       kll.update(0.0)
 
       # 0 should be near the median
-      self.assertAlmostEqual(0.5, kll.get_rank(0.0), delta=0.025)
+      self.assertAlmostEqual(0.5, kll.get_rank(0.0), delta=0.035)
       
       # the median should be near 0
-      self.assertAlmostEqual(0.0, kll.get_quantile(0.5), delta=0.025)
+      self.assertAlmostEqual(0.0, kll.get_quantile(0.5), delta=0.035)
 
       # we also track the min/max independently from the rest of the data
       # which lets us know the full observed data range

--- a/python/tests/req_test.py
+++ b/python/tests/req_test.py
@@ -30,10 +30,10 @@ class reqTest(unittest.TestCase):
       req.update(0.0)
 
       # 0 should be near the median
-      self.assertAlmostEqual(0.5, req.get_rank(0.0), delta=0.03)
+      self.assertAlmostEqual(0.5, req.get_rank(0.0), delta=0.045)
       
       # the median should be near 0
-      self.assertAlmostEqual(0.0, req.get_quantile(0.5), delta=0.03)
+      self.assertAlmostEqual(0.0, req.get_quantile(0.5), delta=0.045)
 
       # we also track the min/max independently from the rest of the data
       # which lets us know the full observed data range

--- a/python/tests/vector_of_kll_test.py
+++ b/python/tests/vector_of_kll_test.py
@@ -39,9 +39,9 @@ class VectorOfKllSketchesTest(unittest.TestCase):
         kll.update(dat)
 
       # 0 should be near the median
-      np.testing.assert_allclose(0.5, kll.get_ranks(0.0), atol=0.025)
+      np.testing.assert_allclose(0.5, kll.get_ranks(0.0), atol=0.035)
       # the median should be near 0
-      np.testing.assert_allclose(0.0, kll.get_quantiles(0.5), atol=0.025)
+      np.testing.assert_allclose(0.0, kll.get_quantiles(0.5), atol=0.035)
       # we also track the min/max independently from the rest of the data
       # which lets us know the full observed data range
       np.testing.assert_allclose(kll.get_min_values(), smin)
@@ -118,9 +118,9 @@ class VectorOfKllSketchesTest(unittest.TestCase):
         kll.update(dat)
 
       # 0 should be near the median
-      np.testing.assert_allclose(0.5, kll.get_ranks(0.0), atol=0.025)
+      np.testing.assert_allclose(0.5, kll.get_ranks(0.0), atol=0.035)
       # the median should be near 0
-      np.testing.assert_allclose(0.0, kll.get_quantiles(0.5), atol=0.025)
+      np.testing.assert_allclose(0.0, kll.get_quantiles(0.5), atol=0.035)
       # we also track the min/max independently from the rest of the data
       # which lets us know the full observed data range
       np.testing.assert_allclose(kll.get_min_values(), smin)


### PR DESCRIPTION
Expanded test margins for relative accuracy python tests by about 50%, for all provided variants of quantiles sketches.

The original margins are generally ok, but we're using random data in the tests (which also function as documentation/tutorials) and don't have a way to make the structures deterministic even for testing. As a result, we end up with the expected real-world "failures" due to low probability events showing up eventually. We have enough independent tests that it's not surprising that one of them is outside the stated tolerance every so often.

The non-quantiles sketches do not have this issue and are unchanged.