### PR TITLE
Build python wheels on releases

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,19 +1,19 @@
 name: Build Python Wheels
 
 on:
+  # allow manual runs
+  workflow_dispatch:
   # run when we tag a release
   release:
     types:
       - "created"
-  # also allow manual runs
-  workflow_dispatch:
 
 env:
   BUILD_TYPE: Release
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.config.name }}
+    name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
I'm not highly confident, but I think the manual trigger part might not work until the workflow in the main branch specifies that option. Since this seems pretty low risk to merge, I'm proposing we try it.