### PR TITLE
Py fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -284,10 +284,47 @@ APPENDIX B: Additional licenses relevant to this product.
     ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
     DEALINGS IN THE SOFTWARE.
     -------------------------------------------------------------
-    Code Locations
+    Code Locations:
       * https://github.com/apache/datasketches-cpp/blob/master/common/test/catch.hpp
     that is adapted from the above.
 
+
+    =============================================================
+    BSD License
+    =============================================================
+    Original source code:
+       https://github.com/pybind/pybind11/blob/master/LICENSE
+
+    Copyright (c) 2016 Wenzel Jakob <wenzel.jakob@epfl.ch>, All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software
+       without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    -------------------------------------------------------------
+    Code Locations:
+    Found only in the convenience binaries distributed from PyPI, which rely
+    on pybind11 code during compilation.
 
 
     =============================================================
@@ -297,7 +334,7 @@ APPENDIX B: Additional licenses relevant to this product.
        https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp
        Placed in the Public Domain by Austin Appleby
     
-    Code Locations
+    Code Locations:
       common/include/MurmurHash3.h
     that is adapted from the above.
     -------------------------------------------------------------
@@ -305,7 +342,7 @@ APPENDIX B: Additional licenses relevant to this product.
       * https://graphics.stanford.edu/~seander/bithacks.html
       * Placed in the Public Domain by Sean Eron Anderson
       
-    Code Locations
+    Code Locations:
       * common/include/ceiling_power_of_2.hpp
     that is adapted from the above.
   

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ envlist = py3
 [testenv]
 deps = pytest
        numpy
-       pybind11 >= 2.6.0
 changedir = python/tests
 commands = pytest
 """

--- a/python/README.md
+++ b/python/README.md
@@ -1,4 +1,6 @@
-# Python Wrapper for Apache DataSketches
+<img src="https://raw.githubusercontent.com/apache/datasketches-website/master/logos/svg/datasketches-HorizontalColor-TM.svg" width="75%" alt="Apache DataSketchs Logo">
+
+# The Apache DataSketches Library for Python
 
 This is the official version of the [Apache DataSketches](https://datasketches.apache.org) Python library.
 
@@ -10,15 +12,15 @@ This package provides a variety of sketches as described below. Wherever a speci
 
 ## Building and Installation
 
-Once cloned, the library can be installed by running `python -m pip install .` in the project root directory, which will also install the necessary dependencies, namely [pybind11](https://github.com/pybind/pybind11) and numpy.
+Once cloned, the library can be installed by running `python -m pip install .` in the project root directory, which will also install the necessary dependencies, namely numpy and [pybind11[global]](https://github.com/pybind/pybind11).
 
 If you prefer to call the `setup.py` build script directly, you must first install `pybind11[global]`, as well as any other dependencies listed under the build-system section in `pyproject.toml`.
 
-The library is also available (or soon will be) from PyPI via `python -m pip install datasketches`.
+The library is also available from PyPI via `python -m pip install datasketches`.
 
 ## Usage
 
-Having installed the library, loading the Apache Datasketches library in Python is simple: `import datasketches`.
+Having installed the library, loading the Apache Datasketches Library in Python is simple: `import datasketches`.
 
 ## Available Sketch Classes
 
@@ -66,7 +68,14 @@ The only developer-specific instructions relate to running unit tests.
 ### Unit tests
 
 The Python unit tests are run with `tox`. To ensure you have all the needed package, from the package base directory run:
-```
+
+```bash
 python -m pip install --upgrade tox
 tox
 ```
+
+## License
+
+The Apache DataSketches Library is distrubted under an Apache 2.0 License.
+
+There may be precompiled binaries provided as a convenience and distributed through PyPI via [https://pypi.org/project/datasketches/] contain compiled code from [pybind11](https://github.com/pybind/pybind11), which is distributed under a BSD license.

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='datasketches',
-    version='3.2.0.1',
+    version='3.3.0.dev0',
     author='Apache Software Foundation',
     author_email='dev@datasketches.apache.org',
     description='The Apache DataSketches Library for Python',

--- a/setup.py
+++ b/setup.py
@@ -81,18 +81,19 @@ class CMakeBuild(build_ext):
 
 setup(
     name='datasketches',
-    version='3.3.0.dev0',
-    author='Apache DataSketches Developers',
+    version='3.2.0.1',
+    author='Apache Software Foundation',
     author_email='dev@datasketches.apache.org',
-    description='A wrapper for the C++ Apache DataSketches library',
+    description='The Apache DataSketches Library for Python',
     license='Apache License 2.0',
     url='http://datasketches.apache.org',
     long_description=open('python/README.md').read(),
+    long_description_content_type='text/markdown',
     packages=find_packages('python'), # python pacakges only in this dir
     package_dir={'':'python'},
     # may need to add all source paths for sdist packages w/o MANIFEST.in
     ext_modules=[CMakeExtension('datasketches')],
     cmdclass={'build_ext': CMakeBuild},
-    install_requires=['numpy', 'pybind11 >= 2.6.0'],
+    install_requires=['numpy'],
     zip_safe=False
 )


### PR DESCRIPTION
pulls in the changes from 3.2.x (license, python description and dependency fixes) and re-aligns the python version with the main branch