### PR TITLE
Restructuring theta so that wrapped compact has standard methods

### DIFF
--- a/theta/test/theta_sketch_test.cpp
+++ b/theta/test/theta_sketch_test.cpp
@@ -269,6 +269,12 @@ TEST_CASE("theta sketch: conversion constructor and wrapped compact", "[theta_sk
     REQUIRE(*it == entry);
     ++it;
   }
+  REQUIRE(ordered_compact3.get_estimate() == ordered_compact1.get_estimate());
+  REQUIRE(ordered_compact3.get_lower_bound(1) == ordered_compact1.get_lower_bound(1));
+  REQUIRE(ordered_compact3.get_upper_bound(1) == ordered_compact1.get_upper_bound(1));
+  REQUIRE(ordered_compact3.is_estimation_mode() == ordered_compact1.is_estimation_mode());
+  REQUIRE(ordered_compact3.get_theta() == ordered_compact1.get_theta());
+
 
   // seed mismatch
   REQUIRE_THROWS_AS(wrapped_compact_theta_sketch::wrap(bytes.data(), bytes.size(), 0), std::invalid_argument);


### PR DESCRIPTION
Introducing a base_theta_sketch_alloc as a base class and moving most
methods to that class, except for iterators, so that
wrapped_compact_theta_sketch can inherit from the same base class as the
rest of the sketch methods, and thus have the same API.