### PR TITLE
KLL inclusive rank

### DIFF
--- a/kll/test/kll_sketch_test.cpp
+++ b/kll/test/kll_sketch_test.cpp
@@ -90,7 +90,9 @@ TEST_CASE("kll sketch", "[kll_sketch]") {
     REQUIRE(sketch.get_n() == 1);
     REQUIRE(sketch.get_num_retained() == 1);
     REQUIRE(sketch.get_rank(1.0f) == 0.0);
+    REQUIRE(sketch.get_rank<true>(1.0f) == 1.0);
     REQUIRE(sketch.get_rank(2.0f) == 1.0);
+    REQUIRE(sketch.get_rank(std::numeric_limits<float>::infinity()) == 1.0);
     REQUIRE(sketch.get_min_value() == 1.0);
     REQUIRE(sketch.get_max_value() == 1.0);
     REQUIRE(sketch.get_quantile(0.5) == 1.0);
@@ -142,8 +144,10 @@ TEST_CASE("kll sketch", "[kll_sketch]") {
     REQUIRE(quantiles[2] == n - 1 );
 
     for (uint32_t i = 0; i < n; i++) {
-      const double trueRank = (double) i / n;
-      REQUIRE(sketch.get_rank(static_cast<float>(i)) == trueRank);
+      const double true_rank = (double) i / n;
+      REQUIRE(sketch.get_rank(static_cast<float>(i)) == true_rank);
+      const double true_rank_inclusive = (double) (i + 1) / n;
+      REQUIRE(sketch.get_rank<true>(static_cast<float>(i)) == true_rank_inclusive);
     }
 
     // the alternative method must produce the same result

--- a/python/src/req_wrapper.cpp
+++ b/python/src/req_wrapper.cpp
@@ -194,6 +194,8 @@ void bind_req_sketch(py::module &m, const char* name) {
          "Returns an approximation to the normalized (fractional) rank of the given value from 0 to 1, inclusive.\n"
          "The resulting approximation has a probabilistic guarantee that can be obtained from the "
          "get_normalized_rank_error(False) function.\n"
+         "With the parameter inclusive=true the weight of the given item is included into the rank."
+         "Otherwise the rank equals the sum of the weights of items less than the given item.\n"
          "If the sketch is empty this returns nan.")
     .def("get_pmf", &dspy::req_sketch_get_pmf<T>, py::arg("split_points"), py::arg("inclusive")=false,
          "Returns an approximation to the Probability Mass Function (PMF) of the input stream "
@@ -203,9 +205,11 @@ void bind_req_sketch(py::module &m, const char* name) {
          "If the sketch is empty this returns an empty vector.\n"
          "split_points is an array of m unique, monotonically increasing float values "
          "that divide the real number line into m+1 consecutive disjoint intervals.\n"
-         "The definition of an 'interval' is inclusive of the left split point (or minimum value) and "
+         "If the parameter inclusive=false, the definition of an 'interval' is inclusive of the left split point (or minimum value) and "
          "exclusive of the right split point, with the exception that the last interval will include "
          "the maximum value.\n"
+         "If the parameter inclusive=true, the definition of an 'interval' is exclusive of the left split point (or minimum value) and "
+         "inclusive of the right split point.\n"
          "It is not necessary to include either the min or max values in these split points.")
     .def("get_cdf", &dspy::req_sketch_get_cdf<T>, py::arg("split_points"), py::arg("inclusive")=false,
          "Returns an approximation to the Cumulative Distribution Function (CDF), which is the "
@@ -215,9 +219,11 @@ void bind_req_sketch(py::module &m, const char* name) {
          "If the sketch is empty this returns an empty vector.\n"
          "split_points is an array of m unique, monotonically increasing float values "
          "that divide the real number line into m+1 consecutive disjoint intervals.\n"
-         "The definition of an 'interval' is inclusive of the left split point (or minimum value) and "
+         "If the parameter inclusive=false, the definition of an 'interval' is inclusive of the left split point (or minimum value) and "
          "exclusive of the right split point, with the exception that the last interval will include "
          "the maximum value.\n"
+         "If the parameter inclusive=true, the definition of an 'interval' is exclusive of the left split point (or minimum value) and "
+         "inclusive of the right split point.\n"
          "It is not necessary to include either the min or max values in these split points.")
     .def("get_rank_lower_bound", &req_sketch<T>::get_rank_lower_bound, py::arg("rank"), py::arg("num_std_dev"),
          "Returns an approximate lower bound on the given normalized rank.\n"

--- a/req/include/req_sketch.hpp
+++ b/req/include/req_sketch.hpp
@@ -28,7 +28,7 @@ namespace datasketches {
 
 template<
   typename T,
-  typename Comparator = std::less<T>,
+  typename Comparator = std::less<T>, // strict weak ordering function (see C++ named requirements: Compare)
   typename SerDe = serde<T>,
   typename Allocator = std::allocator<T>
 >
@@ -123,7 +123,6 @@ public:
    * @param item to be ranked
    * @return an approximate rank of the given item
    */
-
   template<bool inclusive = false>
   double get_rank(const T& item) const;
 


### PR DESCRIPTION
This is to support inclusive get_rank(), get_PMF() and get_CDF() inspired by the implementation of REQ sketch.
Support of inclusive get_quantile() and get_quantiles() will be done separately by reusing the quantiles calculator from the REQ sketch.