### PR TITLE
fix: add missing <stdexcept> includes

### DIFF
--- a/common/include/binomial_bounds.hpp
+++ b/common/include/binomial_bounds.hpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <stdexcept>
 
 /*
  * This class enables the estimation of error bounds given a sample set size, the sampling

--- a/common/include/quantile_sketch_sorted_view_impl.hpp
+++ b/common/include/quantile_sketch_sorted_view_impl.hpp
@@ -21,6 +21,7 @@
 #define QUANTILE_SKETCH_SORTED_VIEW_IMPL_HPP_
 
 #include <algorithm>
+#include <stdexcept>
 
 namespace datasketches {
 

--- a/cpc/include/cpc_compressor_impl.hpp
+++ b/cpc/include/cpc_compressor_impl.hpp
@@ -23,6 +23,7 @@
 #define CPC_COMPRESSOR_IMPL_HPP_
 
 #include <memory>
+#include <stdexcept>
 
 #include "compression_data.hpp"
 #include "cpc_util.hpp"

--- a/cpc/include/cpc_confidence.hpp
+++ b/cpc/include/cpc_confidence.hpp
@@ -23,6 +23,7 @@
 #define CPC_CONFIDENCE_HPP_
 
 #include <cmath>
+#include <stdexcept>
 
 #include "cpc_sketch.hpp"
 

--- a/cpc/include/cpc_union_impl.hpp
+++ b/cpc/include/cpc_union_impl.hpp
@@ -22,6 +22,8 @@
 
 #include "count_zeros.hpp"
 
+#include <stdexcept>
+
 namespace datasketches {
 
 template<typename A>

--- a/cpc/test/cpc_sketch_test.cpp
+++ b/cpc/test/cpc_sketch_test.cpp
@@ -21,6 +21,7 @@
 #include <cstring>
 #include <sstream>
 #include <fstream>
+#include <stdexcept>
 
 #include <catch.hpp>
 

--- a/cpc/test/cpc_union_test.cpp
+++ b/cpc/test/cpc_union_test.cpp
@@ -21,6 +21,8 @@
 
 #include "cpc_union.hpp"
 
+#include <stdexcept>
+
 namespace datasketches {
 
 static const double RELATIVE_ERROR_FOR_LG_K_11 = 0.02;

--- a/fi/include/frequent_items_sketch_impl.hpp
+++ b/fi/include/frequent_items_sketch_impl.hpp
@@ -23,6 +23,7 @@
 #include <cstring>
 #include <limits>
 #include <sstream>
+#include <stdexcept>
 
 #include "memory_operations.hpp"
 

--- a/fi/test/frequent_items_sketch_custom_type_test.cpp
+++ b/fi/test/frequent_items_sketch_custom_type_test.cpp
@@ -19,6 +19,7 @@
 
 #include <catch.hpp>
 #include <sstream>
+#include <stdexcept>
 
 #include "frequent_items_sketch.hpp"
 #include "test_type.hpp"

--- a/fi/test/frequent_items_sketch_test.cpp
+++ b/fi/test/frequent_items_sketch_test.cpp
@@ -20,6 +20,7 @@
 #include <catch.hpp>
 #include <sstream>
 #include <fstream>
+#include <stdexcept>
 
 #include "frequent_items_sketch.hpp"
 

--- a/hll/include/AuxHashMap-internal.hpp
+++ b/hll/include/AuxHashMap-internal.hpp
@@ -20,6 +20,8 @@
 #ifndef _AUXHASHMAP_INTERNAL_HPP_
 #define _AUXHASHMAP_INTERNAL_HPP_
 
+#include <stdexcept>
+
 #include "HllUtil.hpp"
 #include "AuxHashMap.hpp"
 

--- a/hll/include/CompositeInterpolationXTable-internal.hpp
+++ b/hll/include/CompositeInterpolationXTable-internal.hpp
@@ -24,6 +24,7 @@
 #include "CompositeInterpolationXTable.hpp"
 
 #include <exception>
+#include <stdexcept>
 
 namespace datasketches {
 

--- a/hll/include/CouponHashSet-internal.hpp
+++ b/hll/include/CouponHashSet-internal.hpp
@@ -24,6 +24,7 @@
 
 #include <cstring>
 #include <exception>
+#include <stdexcept>
 
 namespace datasketches {
 

--- a/hll/include/CouponList-internal.hpp
+++ b/hll/include/CouponList-internal.hpp
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <stdexcept>
 
 namespace datasketches {
 

--- a/hll/include/HllSketchImpl-internal.hpp
+++ b/hll/include/HllSketchImpl-internal.hpp
@@ -23,6 +23,8 @@
 #include "HllSketchImpl.hpp"
 #include "HllSketchImplFactory.hpp"
 
+#include <stdexcept>
+
 namespace datasketches {
 
 template<typename A>

--- a/hll/include/HllSketchImplFactory.hpp
+++ b/hll/include/HllSketchImplFactory.hpp
@@ -20,6 +20,8 @@
 #ifndef _HLLSKETCHIMPLFACTORY_HPP_
 #define _HLLSKETCHIMPLFACTORY_HPP_
 
+#include <stdexcept>
+
 #include "HllUtil.hpp"
 #include "HllSketchImpl.hpp"
 #include "CouponList.hpp"

--- a/hll/test/AuxHashMapTest.cpp
+++ b/hll/test/AuxHashMapTest.cpp
@@ -19,6 +19,7 @@
 
 #include <catch.hpp>
 #include <memory>
+#include <stdexcept>
 
 #include "AuxHashMap.hpp"
 

--- a/hll/test/CouponHashSetTest.cpp
+++ b/hll/test/CouponHashSetTest.cpp
@@ -26,6 +26,7 @@
 #include <cmath>
 #include <string>
 #include <exception>
+#include <stdexcept>
 
 namespace datasketches {
 

--- a/hll/test/CouponListTest.cpp
+++ b/hll/test/CouponListTest.cpp
@@ -23,6 +23,7 @@
 #include <cmath>
 #include <string>
 #include <exception>
+#include <stdexcept>
 
 #include "hll.hpp"
 #include "CouponList.hpp"

--- a/hll/test/HllArrayTest.cpp
+++ b/hll/test/HllArrayTest.cpp
@@ -21,6 +21,7 @@
 
 #include <exception>
 #include <sstream>
+#include <stdexcept>
 #include <catch.hpp>
 
 namespace datasketches {

--- a/hll/test/HllSketchTest.cpp
+++ b/hll/test/HllSketchTest.cpp
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+#include <stdexcept>
+
 #include "hll.hpp"
 
 #include <catch.hpp>

--- a/hll/test/HllUnionTest.cpp
+++ b/hll/test/HllUnionTest.cpp
@@ -19,6 +19,7 @@
 
 #include <catch.hpp>
 #include <sstream>
+#include <stdexcept>
 
 #include "hll.hpp"
 

--- a/hll/test/TablesTest.cpp
+++ b/hll/test/TablesTest.cpp
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include <stdexcept>
 
 #include <catch.hpp>
 

--- a/kll/include/kll_helper_impl.hpp
+++ b/kll/include/kll_helper_impl.hpp
@@ -21,6 +21,7 @@
 #define KLL_HELPER_IMPL_HPP_
 
 #include <algorithm>
+#include <stdexcept>
 
 namespace datasketches {
 

--- a/kll/include/kll_sketch_impl.hpp
+++ b/kll/include/kll_sketch_impl.hpp
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <iomanip>
 #include <sstream>
+#include <stdexcept>
 
 #include "memory_operations.hpp"
 #include "kll_helper.hpp"

--- a/kll/test/kll_sketch_test.cpp
+++ b/kll/test/kll_sketch_test.cpp
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <sstream>
 #include <fstream>
+#include <stdexcept>
 
 #include <kll_sketch.hpp>
 #include <test_allocator.hpp>

--- a/python/src/kll_wrapper.cpp
+++ b/python/src/kll_wrapper.cpp
@@ -24,6 +24,7 @@
 #include <pybind11/numpy.h>
 #include <sstream>
 #include <vector>
+#include <stdexcept>
 
 namespace py = pybind11;
 

--- a/python/src/req_wrapper.cpp
+++ b/python/src/req_wrapper.cpp
@@ -24,6 +24,7 @@
 #include <pybind11/numpy.h>
 #include <sstream>
 #include <vector>
+#include <stdexcept>
 
 namespace py = pybind11;
 

--- a/python/src/vector_of_kll.cpp
+++ b/python/src/vector_of_kll.cpp
@@ -24,6 +24,7 @@
 #include <pybind11/numpy.h>
 #include <sstream>
 #include <vector>
+#include <stdexcept>
 
 namespace py = pybind11;
 

--- a/req/include/req_sketch.hpp
+++ b/req/include/req_sketch.hpp
@@ -24,6 +24,8 @@
 #include "req_compactor.hpp"
 #include "req_quantile_calculator.hpp"
 
+#include <stdexcept>
+
 namespace datasketches {
 
 template<

--- a/req/test/req_sketch_test.cpp
+++ b/req/test/req_sketch_test.cpp
@@ -24,6 +24,7 @@
 #include <fstream>
 #include <sstream>
 #include <limits>
+#include <stdexcept>
 
 namespace datasketches {
 

--- a/sampling/include/var_opt_sketch_impl.hpp
+++ b/sampling/include/var_opt_sketch_impl.hpp
@@ -25,6 +25,7 @@
 #include <cmath>
 #include <random>
 #include <algorithm>
+#include <stdexcept>
 
 #include "var_opt_sketch.hpp"
 #include "serde.hpp"

--- a/sampling/include/var_opt_union_impl.hpp
+++ b/sampling/include/var_opt_union_impl.hpp
@@ -24,6 +24,7 @@
 
 #include <cmath>
 #include <sstream>
+#include <stdexcept>
 
 namespace datasketches {
 

--- a/sampling/test/var_opt_sketch_test.cpp
+++ b/sampling/test/var_opt_sketch_test.cpp
@@ -27,6 +27,7 @@
 #include <fstream>
 #include <cmath>
 #include <random>
+#include <stdexcept>
 
 #ifdef TEST_BINARY_INPUT_PATH
 static std::string testBinaryInputPath = TEST_BINARY_INPUT_PATH;

--- a/sampling/test/var_opt_union_test.cpp
+++ b/sampling/test/var_opt_union_test.cpp
@@ -27,6 +27,7 @@
 #include <fstream>
 #include <cmath>
 #include <random>
+#include <stdexcept>
 
 #ifdef TEST_BINARY_INPUT_PATH
 static std::string testBinaryInputPath = TEST_BINARY_INPUT_PATH;

--- a/theta/include/bounds_on_ratios_in_sampled_sets.hpp
+++ b/theta/include/bounds_on_ratios_in_sampled_sets.hpp
@@ -22,6 +22,7 @@
 
 #include <cstdint>
 #include <string>
+#include <stdexcept>
 
 #include "bounds_binomial_proportions.hpp"
 

--- a/theta/include/compact_theta_sketch_parser_impl.hpp
+++ b/theta/include/compact_theta_sketch_parser_impl.hpp
@@ -22,6 +22,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include <stdexcept>
 
 namespace datasketches {
 

--- a/theta/include/theta_intersection_base_impl.hpp
+++ b/theta/include/theta_intersection_base_impl.hpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <sstream>
 #include <algorithm>
+#include <stdexcept>
 
 #include "conditional_forward.hpp"
 

--- a/theta/include/theta_set_difference_base_impl.hpp
+++ b/theta/include/theta_set_difference_base_impl.hpp
@@ -21,6 +21,7 @@
 #define THETA_A_SET_DIFFERENCE_BASE_IMPL_HPP_
 
 #include <algorithm>
+#include <stdexcept>
 
 #include "conditional_back_inserter.hpp"
 #include "conditional_forward.hpp"

--- a/theta/include/theta_sketch_impl.hpp
+++ b/theta/include/theta_sketch_impl.hpp
@@ -22,6 +22,7 @@
 
 #include <sstream>
 #include <vector>
+#include <stdexcept>
 
 #include "serde.hpp"
 #include "binomial_bounds.hpp"

--- a/theta/include/theta_union_base_impl.hpp
+++ b/theta/include/theta_union_base_impl.hpp
@@ -21,6 +21,7 @@
 #define THETA_UNION_BASE_IMPL_HPP_
 
 #include <algorithm>
+#include <stdexcept>
 
 #include "conditional_forward.hpp"
 

--- a/theta/include/theta_update_sketch_base_impl.hpp
+++ b/theta/include/theta_update_sketch_base_impl.hpp
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <sstream>
 #include <algorithm>
+#include <stdexcept>
 
 #include "theta_helpers.hpp"
 

--- a/theta/test/theta_a_not_b_test.cpp
+++ b/theta/test/theta_a_not_b_test.cpp
@@ -21,6 +21,8 @@
 
 #include <theta_a_not_b.hpp>
 
+#include <stdexcept>
+
 namespace datasketches {
 
 TEST_CASE("theta a-not-b: empty", "[theta_a_not_b]") {

--- a/theta/test/theta_intersection_test.cpp
+++ b/theta/test/theta_intersection_test.cpp
@@ -21,6 +21,8 @@
 
 #include <theta_intersection.hpp>
 
+#include <stdexcept>
+
 namespace datasketches {
 
 TEST_CASE("theta intersection: invalid", "[theta_intersection]") {

--- a/theta/test/theta_setop_test.cpp
+++ b/theta/test/theta_setop_test.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <sstream>
+#include <stdexcept>
 
 #include <catch.hpp>
 #include <theta_union.hpp>

--- a/theta/test/theta_sketch_test.cpp
+++ b/theta/test/theta_sketch_test.cpp
@@ -21,6 +21,7 @@
 #include <fstream>
 #include <sstream>
 #include <vector>
+#include <stdexcept>
 
 #include <catch.hpp>
 #include <theta_sketch.hpp>

--- a/theta/test/theta_union_test.cpp
+++ b/theta/test/theta_union_test.cpp
@@ -21,6 +21,8 @@
 
 #include <theta_union.hpp>
 
+#include <stdexcept>
+
 namespace datasketches {
 
 TEST_CASE("theta union: empty", "[theta_union]") {

--- a/tuple/include/tuple_sketch_impl.hpp
+++ b/tuple/include/tuple_sketch_impl.hpp
@@ -18,6 +18,7 @@
  */
 
 #include <sstream>
+#include <stdexcept>
 
 #include "binomial_bounds.hpp"
 #include "theta_helpers.hpp"

--- a/tuple/test/tuple_a_not_b_test.cpp
+++ b/tuple/test/tuple_a_not_b_test.cpp
@@ -22,6 +22,7 @@
 #include <catch.hpp>
 #include <tuple_a_not_b.hpp>
 #include <theta_sketch.hpp>
+#include <stdexcept>
 
 namespace datasketches {
 

--- a/tuple/test/tuple_intersection_test.cpp
+++ b/tuple/test/tuple_intersection_test.cpp
@@ -22,6 +22,7 @@
 #include <catch.hpp>
 #include <tuple_intersection.hpp>
 #include <theta_sketch.hpp>
+#include <stdexcept>
 
 namespace datasketches {
 

--- a/tuple/test/tuple_union_test.cpp
+++ b/tuple/test/tuple_union_test.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <iostream>
+#include <stdexcept>
 
 #include <catch.hpp>
 #include <tuple_union.hpp>


### PR DESCRIPTION
## 🔖 Summary

This PR fixes a compilation issue that we've experienced with `python -m pip install .` by adding some missing `#include <stdexcept>` statements to all files invoking the `std::invalid_argument` function.

I'm a bit rusty on C++ but it seems that the compilation is failing due to the CMake compilation order of the files. For instance, I have no issue on my Apple M1 with default Apple Clang 13, but our Linux-based CI is failing.

## ✅ Testing plan

Installing from latest commit `641def5cc4fb7a26fe03e3bd17b735b23f1eecaf` from `apache/datasketches-cpp`
```
# Using fresh shell from `docker run -it python:3.9.9 bash`
apt update && apt install -y git
git clone https://github.com/apache/datasketches-cpp.git
cd datasketches-cpp/
git checkout 641def5cc4fb7a26fe03e3bd17b735b23f1eecaf
python -m pip install .
```

<details>
  <summary>Output</summary>

  ```
  Processing /datasketches-cpp
    DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
     pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.
    Installing build dependencies ... done
    Getting requirements to build wheel ... done
      Preparing wheel metadata ... done
  Collecting numpy
    Downloading numpy-1.22.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (13.4 MB)
       |████████████████████████████████| 13.4 MB 3.5 MB/s
  Building wheels for collected packages: datasketches
    Building wheel for datasketches (PEP 517) ... error
    ERROR: Command errored out with exit status 1:
     command: /usr/local/bin/python /usr/local/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py build_wheel /tmp/tmpxubngxk5
         cwd: /tmp/pip-req-build-953p0a5z
    Complete output (117 lines):
    running bdist_wheel
    running build
    running build_py
    creating build/lib.linux-aarch64-3.9
    creating build/lib.linux-aarch64-3.9/tests
    copying python/tests/fi_test.py -> build/lib.linux-aarch64-3.9/tests
    copying python/tests/hll_test.py -> build/lib.linux-aarch64-3.9/tests
    copying python/tests/vo_test.py -> build/lib.linux-aarch64-3.9/tests
    copying python/tests/__init__.py -> build/lib.linux-aarch64-3.9/tests
    copying python/tests/kll_test.py -> build/lib.linux-aarch64-3.9/tests
    copying python/tests/cpc_test.py -> build/lib.linux-aarch64-3.9/tests
    copying python/tests/req_test.py -> build/lib.linux-aarch64-3.9/tests
    copying python/tests/vector_of_kll_test.py -> build/lib.linux-aarch64-3.9/tests
    copying python/tests/theta_test.py -> build/lib.linux-aarch64-3.9/tests
    creating build/lib.linux-aarch64-3.9/src
    copying python/src/__init__.py -> build/lib.linux-aarch64-3.9/src
    running build_ext
    -- The CXX compiler identification is GNU 10.2.1
    -- Detecting CXX compiler ABI info
    -- Detecting CXX compiler ABI info - done
    -- Check for working CXX compiler: /usr/bin/c++ - skipped
    -- Detecting CXX compile features
    -- Detecting CXX compile features - done
    -- Found Python3: /usr/local/bin/python (found version "3.9.9") found components: Interpreter Development Development.Module Development.Embed
    -- Performing Test HAS_FLTO
    -- Performing Test HAS_FLTO - Success
    -- Found pybind11: /tmp/pip-build-env-o1rh1obe/overlay/include (found version "2.9.1")
    -- Configuring done
    -- Generating done
    -- Build files have been written to: /tmp/pip-req-build-953p0a5z/build/temp.linux-aarch64-3.9
    [ 10%] Building CXX object python/CMakeFiles/python.dir/src/hll_wrapper.cpp.o
    [ 20%] Building CXX object python/CMakeFiles/python.dir/src/datasketches.cpp.o
    [ 30%] Building CXX object python/CMakeFiles/python.dir/src/kll_wrapper.cpp.o
    In file included from /tmp/pip-req-build-953p0a5z/hll/include/hll.private.hpp:23,
                     from /tmp/pip-req-build-953p0a5z/hll/include/hll.hpp:639,
                     from /tmp/pip-req-build-953p0a5z/python/src/hll_wrapper.cpp:20:
    /tmp/pip-req-build-953p0a5z/hll/include/Hll4Array-internal.hpp: In instantiation of ‘void datasketches::Hll4Array<A>::shiftToBiggerCurMin() [with A = std::allocator<unsigned char>]’:
    /tmp/pip-req-build-953p0a5z/hll/include/Hll4Array-internal.hpp:215:11:   required from ‘void datasketches::Hll4Array<A>::internalHll4Update(uint32_t, uint8_t) [with A = std::allocator<unsigned char>; uint32_t = unsigned int; uint8_t = unsigned char]’
    /tmp/pip-req-build-953p0a5z/hll/include/Hll4Array-internal.hpp:137:3:   required from ‘void datasketches::Hll4Array<A>::internalCouponUpdate(uint32_t) [with A = std::allocator<unsigned char>; uint32_t = unsigned int]’
    /tmp/pip-req-build-953p0a5z/hll/include/Hll4Array-internal.hpp:334:5:   required from ‘void datasketches::Hll4Array<A>::mergeHll(const datasketches::HllArray<A>&) [with A = std::allocator<unsigned char>]’
    /tmp/pip-req-build-953p0a5z/hll/include/HllSketchImplFactory.hpp:142:22:   required from ‘static datasketches::Hll4Array<A>* datasketches::HllSketchImplFactory<A>::convertToHll4(const datasketches::HllArray<A>&) [with A = std::allocator<unsigned char>]’
    /tmp/pip-req-build-953p0a5z/hll/include/HllArray-internal.hpp:55:50:   required from ‘datasketches::HllArray<A>* datasketches::HllArray<A>::copyAs(datasketches::target_hll_type) const [with A = std::allocator<unsigned char>]’
    /tmp/pip-req-build-953p0a5z/hll/include/HllUnion-internal.hpp:201:23:   required from ‘static datasketches::HllSketchImpl<A>* datasketches::hll_union_alloc<A>::copy_or_downsample(const datasketches::HllSketchImpl<A>*, uint8_t) [with A = std::allocator<unsigned char>; uint8_t = unsigned char]’
    /tmp/pip-req-build-953p0a5z/hll/include/HllUnion-internal.hpp:240:36:   required from ‘void datasketches::hll_union_alloc<A>::union_impl(const datasketches::hll_sketch_alloc<A>&, uint8_t) [with A = std::allocator<unsigned char>; uint8_t = unsigned char]’
    /tmp/pip-req-build-953p0a5z/hll/include/HllUnion-internal.hpp:48:3:   required from ‘void datasketches::hll_union_alloc<A>::update(const datasketches::hll_sketch_alloc<A>&) [with A = std::allocator<unsigned char>]’
    /tmp/pip-req-build-953p0a5z/python/src/hll_wrapper.cpp:123:55:   required from here
    /tmp/pip-req-build-953p0a5z/hll/include/Hll4Array-internal.hpp:271:25: warning: comparison is always false due to limited range of data type [-Wtype-limits]
      271 |       if (newShiftedVal < 0) {
          |           ~~~~~~~~~~~~~~^~~
    In file included from /tmp/pip-req-build-953p0a5z/common/include/quantile_sketch_sorted_view.hpp:119,
                     from /tmp/pip-req-build-953p0a5z/kll/include/kll_sketch.hpp:28,
                     from /tmp/pip-req-build-953p0a5z/python/src/kll_wrapper.cpp:20:
    /tmp/pip-req-build-953p0a5z/common/include/quantile_sketch_sorted_view_impl.hpp: In member function ‘datasketches::quantile_sketch_sorted_view<T, Comparator, Allocator>::quantile_return_type datasketches::quantile_sketch_sorted_view<T, Comparator, Allocator>::get_quantile(double) const’:
    /tmp/pip-req-build-953p0a5z/common/include/quantile_sketch_sorted_view_impl.hpp:56:38: error: ‘invalid_argument’ is not a member of ‘std’
       56 |   if (total_weight_ == 0) throw std::invalid_argument("supported for cumulative weight only");
          |                                      ^~~~~~~~~~~~~~~~
    [ 40%] Building CXX object python/CMakeFiles/python.dir/src/cpc_wrapper.cpp.o
    gmake[3]: *** [python/CMakeFiles/python.dir/build.make:104: python/CMakeFiles/python.dir/src/kll_wrapper.cpp.o] Error 1
    gmake[3]: *** Waiting for unfinished jobs....
    In file included from /tmp/pip-req-build-953p0a5z/cpc/include/cpc_compressor.hpp:145,
                     from /tmp/pip-req-build-953p0a5z/cpc/include/cpc_sketch.hpp:30,
                     from /tmp/pip-req-build-953p0a5z/python/src/cpc_wrapper.cpp:23:
    /tmp/pip-req-build-953p0a5z/cpc/include/cpc_compressor_impl.hpp: In instantiation of ‘static uint8_t datasketches::cpc_compressor<A>::determine_pseudo_phase(uint8_t, uint32_t) [with A = std::allocator<unsigned char>; uint8_t = unsigned char; uint32_t = unsigned int]’:
    /tmp/pip-req-build-953p0a5z/cpc/include/cpc_compressor_impl.hpp:334:56:   required from ‘void datasketches::cpc_compressor<A>::uncompress_sliding_flavor(const datasketches::compressed_state<A>&, datasketches::uncompressed_state<A>&, uint8_t, uint32_t) const [with A = std::allocator<unsigned char>; uint8_t = unsigned char; uint32_t = unsigned int]’
    /tmp/pip-req-build-953p0a5z/cpc/include/cpc_compressor_impl.hpp:176:7:   required from ‘void datasketches::cpc_compressor<A>::uncompress(const datasketches::compressed_state<A>&, datasketches::uncompressed_state<A>&, uint8_t, uint32_t) const [with A = std::allocator<unsigned char>; uint8_t = unsigned char; uint32_t = unsigned int]’
    /tmp/pip-req-build-953p0a5z/cpc/include/cpc_sketch_impl.hpp:679:33:   required from ‘static datasketches::cpc_sketch_alloc<A> datasketches::cpc_sketch_alloc<A>::deserialize(const void*, size_t, uint64_t, const A&) [with A = std::allocator<unsigned char>; size_t = long unsigned int; uint64_t = long unsigned int]’
    /tmp/pip-req-build-953p0a5z/python/src/cpc_wrapper.cpp:35:78:   required from here
    /tmp/pip-req-build-953p0a5z/cpc/include/cpc_compressor_impl.hpp:450:15: warning: comparison is always false due to limited range of data type [-Wtype-limits]
      450 |     if (phase < 0 || phase >= 16) throw std::out_of_range("wrong phase");
          |         ~~~~~~^~~
    gmake[2]: *** [CMakeFiles/Makefile2:657: python/CMakeFiles/python.dir/all] Error 2
    gmake[1]: *** [CMakeFiles/Makefile2:664: python/CMakeFiles/python.dir/rule] Error 2
    gmake: *** [Makefile:329: python] Error 2
    Traceback (most recent call last):
      File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 349, in <module>
        main()
      File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 331, in main
        json_out['return_val'] = hook(**hook_input['kwargs'])
      File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 248, in build_wheel
        return _build_backend().build_wheel(wheel_directory, config_settings,
      File "/tmp/pip-build-env-o1rh1obe/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 244, in build_wheel
        return self._build_with_temp_dir(['bdist_wheel'], '.whl',
      File "/tmp/pip-build-env-o1rh1obe/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 229, in _build_with_temp_dir
        self.run_setup()
      File "/tmp/pip-build-env-o1rh1obe/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 174, in run_setup
        exec(compile(code, __file__, 'exec'), locals())
      File "setup.py", line 82, in <module>
        setup(
      File "/tmp/pip-build-env-o1rh1obe/overlay/lib/python3.9/site-packages/setuptools/__init__.py", line 155, in setup
        return distutils.core.setup(**attrs)
      File "/tmp/pip-build-env-o1rh1obe/overlay/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 148, in setup
        return run_commands(dist)
      File "/tmp/pip-build-env-o1rh1obe/overlay/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 163, in run_commands
        dist.run_commands()
      File "/tmp/pip-build-env-o1rh1obe/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 967, in run_commands
        self.run_command(cmd)
      File "/tmp/pip-build-env-o1rh1obe/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 986, in run_command
        cmd_obj.run()
      File "/tmp/pip-build-env-o1rh1obe/overlay/lib/python3.9/site-packages/wheel/bdist_wheel.py", line 299, in run
        self.run_command('build')
      File "/tmp/pip-build-env-o1rh1obe/overlay/lib/python3.9/site-packages/setuptools/_distutils/cmd.py", line 313, in run_command
        self.distribution.run_command(command)
      File "/tmp/pip-build-env-o1rh1obe/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 986, in run_command
        cmd_obj.run()
      File "/tmp/pip-build-env-o1rh1obe/overlay/lib/python3.9/site-packages/setuptools/_distutils/command/build.py", line 135, in run
        self.run_command(cmd_name)
      File "/tmp/pip-build-env-o1rh1obe/overlay/lib/python3.9/site-packages/setuptools/_distutils/cmd.py", line 313, in run_command
        self.distribution.run_command(command)
      File "/tmp/pip-build-env-o1rh1obe/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 986, in run_command
        cmd_obj.run()
      File "setup.py", line 45, in run
        self.build_extension(ext)
      File "setup.py", line 78, in build_extension
        subprocess.check_call(['cmake', '--build', '.', '--target', 'python'] + build_args,
      File "/usr/local/lib/python3.9/subprocess.py", line 373, in check_call
        raise CalledProcessError(retcode, cmd)
    subprocess.CalledProcessError: Command '['cmake', '--build', '.', '--target', 'python', '--config', 'Release', '--', '-j2']' returned non-zero exit status 2.
    ----------------------------------------
    ERROR: Failed building wheel for datasketches
  Failed to build datasketches
  ERROR: Could not build wheels for datasketches which use PEP 517 and cannot be installed directly
  WARNING: You are using pip version 21.2.4; however, version 22.0.3 is available.
  You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
  ```
</details>

Installing from branch`fix-python-build` from `aseure/datasketches-cpp`
```
# Using fresh shell from `docker run -it python:3.9.9 bash`
apt update && apt install -y git
git clone https://github.com/aseure/datasketches-cpp.git
cd datasketches-cpp/
git checkout fix-python-build
python -m pip install .
```

<details>
  <summary>Output</summary>

  ```
  Processing /datasketches-cpp
    DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
     pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.
    Installing build dependencies ... done
    Getting requirements to build wheel ... done
      Preparing wheel metadata ... done
  Collecting numpy
    Downloading numpy-1.22.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (13.4 MB)
       |████████████████████████████████| 13.4 MB 2.9 MB/s
  Building wheels for collected packages: datasketches
    Building wheel for datasketches (PEP 517) ... done
    Created wheel for datasketches: filename=datasketches-3.4.0.dev0-cp39-cp39-linux_aarch64.whl size=446665 sha256=216e93b13201dfa8c46b23861e5324bbb302f5719bc122d0fdfa9b6e51319a48
    Stored in directory: /root/.cache/pip/wheels/f6/fd/0a/a4b285039f77385695ed92406e03e71b5a7f9c6bdb3b1b16a6
  Successfully built datasketches
  Installing collected packages: numpy, datasketches
  Successfully installed datasketches-3.4.0.dev0 numpy-1.22.2
  WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
  WARNING: You are using pip version 21.2.4; however, version 22.0.3 is available.
  You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
  ```
</details>