### PR TITLE
is CouponHashSet deserialization incorrect?

### DIFF
--- a/hll/include/CouponHashSet-internal.hpp
+++ b/hll/include/CouponHashSet-internal.hpp
@@ -114,10 +114,9 @@ CouponHashSet<A>* CouponHashSet<A>::newSet(const void* bytes, size_t len, const 
   } else {
     sketch->coupons_.resize(1ULL << lgArrInts);
     sketch->couponCount_ = couponCount;
-    // only need to read valid coupons, unlike in stream case
     std::memcpy(sketch->coupons_.data(),
                 data + hll_constants::HASH_SET_INT_ARR_START,
-                couponCount * sizeof(uint32_t));
+                couponsInArray * sizeof(uint32_t));
   }
 
   return sketch;


### PR DESCRIPTION
When deserializing an updatable CouponHashSet from a byte array, wouldn't you need to copy the entire coupons array rather than just using couponCount since the hash array is not populated sequentially like the CouponList?