### PR TITLE
KLL cleanup

### DIFF
--- a/kll/include/kll_helper_impl.hpp
+++ b/kll/include/kll_helper_impl.hpp
@@ -230,7 +230,7 @@ kll_helper::compress_result kll_helper::general_compress(uint16_t k, uint8_t m, 
       // move level over as is
       // make sure we are not moving data upwards
       if (raw_beg < out_levels[current_level]) throw std::logic_error("wrong move");
-      std::move(&items[raw_beg], &items[raw_lim], &items[out_levels[current_level]]);
+      std::move(items + raw_beg, items + raw_lim, items + out_levels[current_level]);
       out_levels[current_level + 1] = out_levels[current_level] + raw_pop;
     } else {
       // The sketch is too full AND this level is too full, so we compact it
@@ -251,7 +251,7 @@ kll_helper::compress_result kll_helper::general_compress(uint16_t k, uint8_t m, 
 
       // level zero might not be sorted, so we must sort it if we wish to compact it
       if ((current_level == 0) && !is_level_zero_sorted) {
-        std::sort(&items[adj_beg], &items[adj_beg + adj_pop], C());
+        std::sort(items + adj_beg, items + adj_beg + adj_pop, C());
       }
 
       if (pop_above == 0) { // Level above is empty, so halve up

--- a/kll/include/kll_sketch.hpp
+++ b/kll/include/kll_sketch.hpp
@@ -170,7 +170,7 @@ class kll_sketch {
     using comparator = C;
 
     static const uint8_t DEFAULT_M = 8;
-    // TODO: Redundant and deprecated. Will be remove din next major version.
+    // TODO: Redundant and deprecated. Will be removed in next major version.
     static const uint16_t DEFAULT_K = kll_constants::DEFAULT_K;
     static const uint16_t MIN_K = DEFAULT_M;
     static const uint16_t MAX_K = (1 << 16) - 1;


### PR DESCRIPTION
&array[index] can have undefined behavior if index == size to obtain an equivalent of the end iterator