### PR TITLE
update NOTICE to align with java. 

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Apache DataSketches Java
+Apache DataSketches C++ and Python
 Copyright 2022 The Apache Software Foundation
 
 Copyright 2015-2018 Yahoo Inc.

--- a/NOTICE
+++ b/NOTICE
@@ -1,11 +1,12 @@
-Apache DataSketches-cpp
-Copyright 2020-2021 The Apache Software Foundation
+Apache DataSketches Java
+Copyright 2022 The Apache Software Foundation
 
-Copyright 2015-2018 Yahoo
-Copyright 2019 Verizon Media
+Copyright 2015-2018 Yahoo Inc.
+Copyright 2019-2020 Verizon Media
+Copyright 2021 Yahoo Inc.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 Prior to moving to ASF, the software for this project was developed at
-Yahoo (now Verizon Media) (https://developer.yahoo.com).
+Yahoo Inc. (https://developer.yahoo.com).


### PR DESCRIPTION
a bunch of documentation taken from java pre-dates the cpp repo, so keeping the 2015 copyright start date