### PR TITLE
remove unnecessary components from python wheel

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -55,6 +55,6 @@ jobs:
         with:
           python-version: '3.8' # 3.x grabs latest minor version of python3, but 3.9 not fully supported yet
       - name: Install Python dependencies
-        run: python -m pip install --upgrade pip setuptools wheel numpy tox pytest
+        run: python -m pip install --upgrade pip setuptools wheel tox
       - name: Build and run Python tests
         run: python -m tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,8 +7,6 @@ global-include *.bin
 
 global-exclude .git*
 
-recursive-include python/pybind11 *
-
 graft cmake
 graft common
 graft cpc

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@
 
 import os
 import sys
-import sysconfig
 import platform
 import subprocess
 
@@ -89,7 +88,7 @@ setup(
     url='http://datasketches.apache.org',
     long_description=open('python/README.md').read(),
     long_description_content_type='text/markdown',
-    packages=find_packages('python'), # python pacakges only in this dir
+    packages=find_packages(where='python',exclude=['src','*tests*']), # src not needed if only the .so
     package_dir={'':'python'},
     # may need to add all source paths for sdist packages w/o MANIFEST.in
     ext_modules=[CMakeExtension('datasketches')],


### PR DESCRIPTION
As suggested in #290

We will probably need to tweak setup.py (or a config) again once we try adding custom serde support, but for now we should clean this up.