### PR TITLE
remove pip as a build-system dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = ["wheel",
             "setuptools >= 30.3.0",
             "cmake >= 3.16",
-            "pip >= 10.0",
             "pybind11[global] >= 2.6.0"]
 build-backend = "setuptools.build_meta"
 

--- a/python/README.md
+++ b/python/README.md
@@ -76,7 +76,7 @@ The only developer-specific instructions relate to running unit tests.
 
 ### Unit tests
 
-The Python unit tests are run via `tox`, with no arguments, from the project root directory -- not the python subdirectory. Tox creates a temporary virtual environment in which to build and run teh unit tests. In the event you are missing the necessary pacakge, tox may be installed with `python3 -m pip install --upgrade tox`.
+The Python unit tests are run via `tox`, with no arguments, from the project root directory -- not the python subdirectory. Tox creates a temporary virtual environment in which to build and run the unit tests. In the event you are missing the necessary pacakge, tox may be installed with `python3 -m pip install --upgrade tox`.
 
 ## License
 

--- a/python/pybind11Path.cmd
+++ b/python/pybind11Path.cmd
@@ -1,3 +1,3 @@
 @echo off
 :: Takes path to the Python interpreter and returns the path to pybind11
-%1 -m pip show pybind11 | %1 -c "import sys,re;[sys.stdout.write(re.sub('^Location:\\s+','',line)) for line in sys.stdin if re.search('^Location:\\s+',line)]"
+%1 -c "import pybind11,sys;sys.stdout.write(pybind11.get_cmake_dir())"


### PR DESCRIPTION
Remove pip as a build-system dependency in pyproject.toml to fix ci failure on Windows.

* Simplify pybind11Path.cmd to not require pip in favor of using pybind11's python method get_cmake_dir()
* incidental typo fix in README.md

The pyproject.toml build-system dependency on pip causes the following error when run on Windows (during the python tests) e.g.:
```
ERROR: To modify pip, please run the following command:
  D:\a\datasketches-cpp\datasketches-cpp\.tox\py3\Scripts\python.EXE -m pip install --ignore-installed --no-user --prefix C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-izfez3j3\overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- wheel setuptools >= 30.3.0 cmake >= 3.16 pip >= 10.0 pybind11[global] >= 2.6.0
```
For context on this error see discussion here: https://github.com/pypa/pip/issues/11120#issuecomment-1126669044

apache/datasketches-cpp appears to be hitting this error, so hopefully this change can resolve that:
https://github.com/apache/datasketches-cpp/runs/7328922009?check_suite_focus=true#step:8:39