### PR TITLE
Add python serde support for varopt sketches

### DIFF
--- a/common/include/memory_operations.hpp
+++ b/common/include/memory_operations.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <exception>
 #include <iostream>
+#include <string>
 
 namespace datasketches {
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -50,7 +50,13 @@ target_link_libraries(python
 
 set_target_properties(python PROPERTIES
   PREFIX ""
-  OUTPUT_NAME datasketches
+  OUTPUT_NAME _datasketches
+)
+
+target_include_directories(python
+  PUBLIC
+    $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
 # ensure we make a .so on Mac rather than .dylib
@@ -71,4 +77,5 @@ target_sources(python
     src/quantiles_wrapper.cpp
     src/ks_wrapper.cpp
     src/vector_of_kll.cpp
+    src/py_serde.cpp
 )

--- a/python/datasketches/PySerDe.py
+++ b/python/datasketches/PySerDe.py
@@ -15,13 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from _datasketches import PyObjectSerde
+from _datasketches import PyObjectSerDe
 
 import struct
 
 # This file provides several Python SerDe implementation examples.
 #
-# Each implementation must extend the PyObjectSerde class and define
+# Each implementation must extend the PyObjectSerDe class and define
 # three methods:
 #   * get_size(item) returns an int of the number of bytes needed to
 #     serialize the given item
@@ -37,7 +37,7 @@ import struct
 # This format allows pre-allocating each string, at the cost of
 # additional storage. Using this format, the serialized string consumes
 # 4 + len(item) bytes.
-class PyStringsSerDe(PyObjectSerde):
+class PyStringsSerDe(PyObjectSerDe):
   def get_size(self, item):
     return int(4 + len(item))
 
@@ -56,7 +56,7 @@ class PyStringsSerDe(PyObjectSerde):
 
 # Implements an integer-encoding scheme where each integer is written
 # as a 32-bit (4 byte) little-endian value.
-class PyIntsSerDe(PyObjectSerde):
+class PyIntsSerDe(PyObjectSerDe):
   def get_size(self, item):
     return int(4)
 
@@ -68,7 +68,7 @@ class PyIntsSerDe(PyObjectSerde):
     return (val, 4)
 
 
-class PyLongsSerDe(PyObjectSerde):
+class PyLongsSerDe(PyObjectSerDe):
   def get_size(self, item):
     return int(8)
 
@@ -80,7 +80,7 @@ class PyLongsSerDe(PyObjectSerde):
     return (val, 8)
 
 
-class PyFloatsSerDe(PyObjectSerde):
+class PyFloatsSerDe(PyObjectSerDe):
   def get_size(self, item):
     return int(4)
 
@@ -92,7 +92,7 @@ class PyFloatsSerDe(PyObjectSerde):
     return (val, 4)
 
 
-class PyDoublesSerDe(PyObjectSerde):
+class PyDoublesSerDe(PyObjectSerDe):
   def get_size(self, item):
     return int(8)
 

--- a/python/datasketches/PySerDe.py
+++ b/python/datasketches/PySerDe.py
@@ -1,0 +1,104 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from _datasketches import PyObjectSerde
+
+import struct
+
+# This file provides several Python SerDe implementation examples.
+#
+# Each implementation must extend the PyObjectSerde class and define
+# three methods:
+#   * get_size(item) returns an int of the number of bytes needed to
+#     serialize the given item
+#   * to_bytes(item) returns a bytes object representing a serialized
+#     version of the given item
+#   * from_bytes(data, offset) takes a bytes object (data) and an offset
+#     indicating where in the data array to start reading. The method
+#     returns a tuple with the newly reconstructed object and the
+#     total number of bytes beyond the offset read from the input data.
+
+# Implements a simple string-encoding scheme where a string is
+# written as <num_bytes> <string_contents>, with no null termination.
+# This format allows pre-allocating each string, at the cost of
+# additional storage. Using this format, the serialized string consumes
+# 4 + len(item) bytes.
+class PyStringsSerDe(PyObjectSerde):
+  def get_size(self, item):
+    return int(4 + len(item))
+
+  def to_bytes(self, item: str):
+    b = bytearray()
+    b.extend(len(item).to_bytes(4, 'little'))
+    b.extend(map(ord,item))
+    return bytes(b)
+
+  def from_bytes(self, data: bytes, offset: int):
+    num_chars = int.from_bytes(data[offset:offset+3], 'little')
+    if (num_chars < 0 or num_chars > offset + len(data)):
+        raise IndexError(f'num_chars read must be non-negative and not larger than the buffer. Found {num_chars}')
+    str = data[offset+4:offset+4+num_chars].decode()
+    return (str, 4+num_chars)
+
+# Implements an integer-encoding scheme where each integer is written
+# as a 32-bit (4 byte) little-endian value.
+class PyIntsSerDe(PyObjectSerde):
+  def get_size(self, item):
+    return int(4)
+
+  def to_bytes(self, item):
+    return struct.pack('i', item)
+
+  def from_bytes(self, data: bytes, offset: int):
+    val = struct.unpack_from('i', data, offset)[0]
+    return (val, 4)
+
+
+class PyLongsSerDe(PyObjectSerde):
+  def get_size(self, item):
+    return int(8)
+
+  def to_bytes(self, item):
+    return struct.pack('l', item)
+
+  def from_bytes(self, data: bytes, offset: int):
+    val = struct.unpack_from('l', data, offset)[0]
+    return (val, 8)
+
+
+class PyFloatsSerDe(PyObjectSerde):
+  def get_size(self, item):
+    return int(4)
+
+  def to_bytes(self, item):
+    return struct.pack('f', item)
+
+  def from_bytes(self, data: bytes, offset: int):
+    val = struct.unpack_from('f', data, offset)[0]
+    return (val, 4)
+
+
+class PyDoublesSerDe(PyObjectSerde):
+  def get_size(self, item):
+    return int(8)
+
+  def to_bytes(self, item):
+    return struct.pack('d', item)
+
+  def from_bytes(self, data: bytes, offset: int):
+    val = struct.unpack_from('d', data, offset)[0]
+    return (val, 8)

--- a/python/datasketches/__init__.py
+++ b/python/datasketches/__init__.py
@@ -14,3 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+name = 'datasketches'
+
+from .PySerDe import PyFloatsSerDe, PyStringsSerDe
+
+from _datasketches import *

--- a/python/datasketches/__init__.py
+++ b/python/datasketches/__init__.py
@@ -17,6 +17,6 @@
 
 name = 'datasketches'
 
-from .PySerDe import PyFloatsSerDe, PyStringsSerDe
+from .PySerDe import *
 
 from _datasketches import *

--- a/python/include/py_serde.hpp
+++ b/python/include/py_serde.hpp
@@ -28,23 +28,58 @@ namespace py = pybind11;
 
 namespace datasketches {
 
+/**
+ * @brief The py_object_serde is an abstract class that implements the
+ * datasketches serde interface, and is used to allow custom Python
+ * serialization of items wrapped as generic py::object types. The actual
+ * Python implementation classes must extend the PyObjectSerDe class.
+ */
 struct py_object_serde {
-  // only raw bytes serialization, no stream
+  /**
+   * @brief Get the serialized size of an object, in bytes
+   * 
+   * @param item A provided item
+   * @return int64_t The serialized size of the item, in bytes
+   */
   virtual int64_t get_size(const py::object& item) const = 0;
+  
+  /**
+   * @brief Serializes an item to a bytes object
+   * 
+   * @param item A provided item
+   * @return The serialized image of the item as a Python bytes object
+   */
   virtual py::bytes to_bytes(const py::object& item) const = 0;
+  
+  /**
+   * @brief Constructs an object from a serialized image, reading the
+   * incoming buffer starting at the specified offset.
+   * 
+   * @param bytes A buffer containing items from a serialized sketch
+   * @param offset The starting offset into the bytes buffer
+   * @return A Python tuple of the reconstructed item and the total number of bytes read
+   */
   virtual py::tuple from_bytes(py::bytes& bytes, size_t offset) const = 0;
 
   virtual ~py_object_serde() = default;
 
+  // these methods are required by the serde interface; see common/include/serde.hpp for
+  // default implementations for C++ std::string and numeric types.
   size_t size_of_item(const py::object& item) const;
   size_t serialize(void* ptr, size_t capacity, const py::object* items, unsigned num) const;
   size_t deserialize(const void* ptr, size_t capacity, py::object* items, unsigned num) const;
 };
 
-struct PyObjectSerde : public py_object_serde {
+/**
+ * @brief The PyObjectSerDe class provides a concrete base class
+ * that pybind11 uses as a "trampoline" to pass calls through to
+ * the abstract py_object_serde class. Custom Python serde implementations
+ * must extend this class.
+ */
+struct PyObjectSerDe : public py_object_serde {
   using py_object_serde::py_object_serde;
 
-  // trampoline (need one for each virtual function)
+  // trampoline definitions -- need one for each virtual function
   int64_t get_size(const py::object& item) const override {
     PYBIND11_OVERRIDE_PURE(
       int64_t,         // Return type

--- a/python/include/py_serde.hpp
+++ b/python/include/py_serde.hpp
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/functional.h>
+#include <sstream>
+
+#ifndef _PY_SERDE_HPP_
+#define _PY_SERDE_HPP_
+
+namespace py = pybind11;
+
+namespace datasketches {
+
+struct py_object_serde {
+  // only raw bytes serialization, no stream
+  virtual int64_t get_size(const py::object& item) const = 0;
+  virtual py::bytes to_bytes(const py::object& item) const = 0;
+  virtual py::tuple from_bytes(py::bytes& bytes, size_t offset) const = 0;
+
+  virtual ~py_object_serde() = default;
+
+  size_t size_of_item(const py::object& item) const;
+  size_t serialize(void* ptr, size_t capacity, const py::object* items, unsigned num) const;
+  size_t deserialize(const void* ptr, size_t capacity, py::object* items, unsigned num) const;
+};
+
+struct PyObjectSerde : public py_object_serde {
+  using py_object_serde::py_object_serde;
+
+  // trampoline (need one for each virtual function)
+  int64_t get_size(const py::object& item) const override {
+    PYBIND11_OVERRIDE_PURE(
+      int64_t,         // Return type
+      py_object_serde, // Parent class
+      get_size,        // Name of function in C++ (must match Python name)
+      item             // Argument(s)
+    );
+  }
+
+  py::bytes to_bytes(const py::object& item) const override {
+    PYBIND11_OVERRIDE_PURE(
+      py::bytes,       // Return type
+      py_object_serde, // Parent class
+      to_bytes,        // Name of function in C++ (must match Python name)
+      item             // Argument(s)
+    );
+  }
+
+  py::tuple from_bytes(py::bytes& bytes, size_t offset) const override {
+    PYBIND11_OVERRIDE_PURE(
+      py::tuple,        // Return type
+      py_object_serde,  // Parent class
+      from_bytes,       // Name of function in C++ (must match Python name)
+      bytes, offset     // Argument(s)
+    );
+  }
+};
+
+}
+
+#endif // _PY_SERDE_HPP_

--- a/python/pybind11Path.cmd
+++ b/python/pybind11Path.cmd
@@ -1,3 +1,21 @@
+:: Licensed to the Apache Software Foundation (ASF) under one
+:: or more contributor license agreements.  See the NOTICE file
+:: distributed with this work for additional information
+:: regarding copyright ownership.  The ASF licenses this file
+:: to you under the Apache License, Version 2.0 (the
+:: "License"); you may not use this file except in compliance
+:: with the License.  You may obtain a copy of the License at
+::
+::   http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing,
+:: software distributed under the License is distributed on an
+:: "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+:: KIND, either express or implied.  See the License for the
+:: specific language governing permissions and limitations
+:: under the License.
+
+
 @echo off
 :: Takes path to the Python interpreter and returns the path to pybind11
 %1 -c "import pybind11,sys;sys.stdout.write(pybind11.get_cmake_dir())"

--- a/python/src/__init__.py
+++ b/python/src/__init__.py
@@ -1,2 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 name = "datasketches"
- 

--- a/python/src/datasketches.cpp
+++ b/python/src/datasketches.cpp
@@ -21,6 +21,7 @@
 
 namespace py = pybind11;
 
+// sketches
 void init_hll(py::module& m);
 void init_kll(py::module& m);
 void init_fi(py::module& m);
@@ -29,10 +30,13 @@ void init_theta(py::module& m);
 void init_vo(py::module& m);
 void init_req(py::module& m);
 void init_quantiles(py::module& m);
-void init_kolmogorov_smirnov(py::module& m);
 void init_vector_of_kll(py::module& m);
 
-PYBIND11_MODULE(datasketches, m) {
+// supporting objects
+void init_kolmogorov_smirnov(py::module& m);
+void init_serde(py::module& m);
+
+PYBIND11_MODULE(_datasketches, m) {
   init_hll(m);
   init_kll(m);
   init_fi(m);
@@ -41,6 +45,8 @@ PYBIND11_MODULE(datasketches, m) {
   init_vo(m);
   init_req(m);
   init_quantiles(m);
-  init_kolmogorov_smirnov(m);
   init_vector_of_kll(m);
+
+  init_kolmogorov_smirnov(m);
+  init_serde(m);
 }

--- a/python/src/py_serde.cpp
+++ b/python/src/py_serde.cpp
@@ -46,7 +46,7 @@ namespace datasketches {
 
   size_t py_object_serde::serialize(void* ptr, size_t capacity, const py::object* items, unsigned num) const {
     size_t bytes_written = 0;
-    pybind11::gil_scoped_acquire acquire;
+    py::gil_scoped_acquire acquire;
     for (unsigned i = 0; i < num; ++i) {
       std::string bytes = to_bytes(items[i]); // implicit cast from py::bytes
       check_memory_size(bytes_written + bytes.size(), capacity);
@@ -54,7 +54,7 @@ namespace datasketches {
       ptr = static_cast<char*>(ptr) + bytes.size();
       bytes_written += bytes.size();
     }
-    pybind11::gil_scoped_release release;
+    py::gil_scoped_release release;
     return bytes_written;
   }
 
@@ -63,7 +63,7 @@ namespace datasketches {
     unsigned i = 0;
     bool failure = false;
     bool error_from_python = false;
-    pybind11::gil_scoped_acquire acquire;
+    py::gil_scoped_acquire acquire;
 
     // copy data into bytes only once
     py::bytes bytes(static_cast<const char*>(ptr), capacity);
@@ -77,7 +77,6 @@ namespace datasketches {
         break;
       }
 
-      // TODO: check bytes_and_len size is exactly 2?
       size_t length = py::cast<size_t>(bytes_and_len[1]);
       if (bytes_read + length > capacity) {
         bytes_read += length; // use this value to report the error
@@ -104,7 +103,7 @@ namespace datasketches {
       }
     }
 
-    pybind11::gil_scoped_release release;
+    py::gil_scoped_release release;
     return bytes_read;
   }
 

--- a/python/src/vo_wrapper.cpp
+++ b/python/src/vo_wrapper.cpp
@@ -97,7 +97,6 @@ std::string vo_sketch_to_string(const var_opt_sketch<T>& sk, bool print_items) {
       // using internal str() method then casting to C++ std::string
       py::str item_pystr(item.first);
       std::string item_str = py::cast<std::string>(item_pystr);
-      // item.second is guaranteed to be a double
       ss << i++ << ": " << item_str << "\twt = " << item.second << std::endl;
     }
     return ss.str();
@@ -137,10 +136,10 @@ void bind_vo_sketch(py::module &m, const char* name) {
          "Applies a provided predicate to the sketch and returns the estimated total weight matching the predicate, as well "
          "as upper and lower bounds on the estimate and the total weight processed by the sketch")
     .def("get_serialized_size_bytes", &dspy::vo_sketch_size_bytes<T>, py::arg("serde"),
-         "Computes the size in bytes needed to serialize the current sketch")
+        "Computes the size in bytes needed to serialize the current sketch")
     .def("serialize", &dspy::vo_sketch_serialize<T>, py::arg("serde"), "Serialize the var opt sketch using the provided serde")
     .def_static("deserialize", &dspy::vo_sketch_deserialize<T>, py::arg("bytes"), py::arg("serde"),
-         "Constructs a var opt sketch from the given bytes using the provided serde")
+        "Constructs a var opt sketch from the given bytes using the provided serde")
     ;
 }
 

--- a/python/src/vo_wrapper.cpp
+++ b/python/src/vo_wrapper.cpp
@@ -19,15 +19,39 @@
 
 #include "var_opt_sketch.hpp"
 #include "var_opt_union.hpp"
+#include "py_serde.hpp"
 
 #include <pybind11/pybind11.h>
-#include <pybind11/functional.h>
-#include <sstream>
 
 namespace py = pybind11;
 
 namespace datasketches {
+
 namespace python {
+
+template<typename T>
+var_opt_sketch<T> vo_sketch_deserialize(py::bytes& skBytes, py_object_serde *sd) {
+  std::string skStr = skBytes; // implicit cast
+  return var_opt_sketch<T>::deserialize(skStr.c_str(), skStr.length(), *sd);
+}
+
+template<typename T>
+py::object vo_sketch_serialize(const var_opt_sketch<T>& sk, py_object_serde *sd) {
+  auto serResult = sk.serialize(0, *sd);
+  return py::bytes((char*)serResult.data(), serResult.size());
+}
+
+template<typename T>
+var_opt_union<T> vo_union_deserialize(py::bytes& uBytes, py_object_serde *sd) {
+  std::string uStr = uBytes; // implicit cast
+  return var_opt_union<T>::deserialize(uStr.c_str(), uStr.length(), *sd);
+}
+
+template<typename T>
+py::object vo_union_serialize(const var_opt_union<T>& u, py_object_serde *sd) {
+  auto serResult = u.serialize(0, *sd);
+  return py::bytes((char*)serResult.data(), serResult.size());
+}
 
 template<typename T>
 py::list vo_sketch_get_samples(const var_opt_sketch<T>& sk) {
@@ -96,17 +120,17 @@ void bind_vo_sketch(py::module &m, const char* name) {
     .def_property_readonly("num_samples", &var_opt_sketch<T>::get_num_samples,
          "Returns the number of samples currently in the sketch")
     .def("get_samples", &dspy::vo_sketch_get_samples<T>,
-         "Retyrns the set of samples in the sketch")
+         "Returns the set of samples in the sketch")
     .def("is_empty", &var_opt_sketch<T>::is_empty,
          "Returns True if the sketch is empty, otherwise False")
     .def("estimate_subset_sum", &dspy::vo_sketch_estimate_subset_sum<T>,
          "Applies a provided predicate to the sketch and returns the estimated total weight matching the predicate, as well "
          "as upper and lower bounds on the estimate and the total weight processed by the sketch")
-    // As of writing, not yet clear how to serialize arbitrary python objects,
-    // especially in any sort of language-portable way
-    //.def("get_serialized_size_bytes", &var_opt_sketch<T>::get_serialized_size_bytes)
-    //.def("serialize", &dspy::vo_sketch_serialize<T>)
-    //.def_static("deserialize", &dspy::vo_sketch_deserialize<T>)
+    //.def("get_serialized_size_bytes", &var_opt_sketch<T>::get_serialized_size_bytes, py::arg("serde"),
+    //     "Computes the size in bytes needed to serialize the current sketch")
+    .def("serialize", &dspy::vo_sketch_serialize<T>, py::arg("serde"), "Serialize the var opt sketch using the provided serde")
+    .def_static("deserialize", &dspy::vo_sketch_deserialize<T>, py::arg("bytes"), py::arg("serde"),
+         "Constructs a var opt sketch from the given bytes using the provided serde")
     ;
 }
 
@@ -126,11 +150,11 @@ void bind_vo_union(py::module &m, const char* name) {
          "Returns a sketch corresponding to the union result")
     .def("reset", &var_opt_union<T>::reset,
          "Resets the union to the empty state")
-    // As of writing, not yet clear how to serialize arbitrary python objects,
-    // especially in any sort of language-portable way
-    //.def("get_serialized_size_bytes", &var_opt_sketch<T>::get_serialized_size_bytes)
-    //.def("serialize", &dspy::vo_union_serialize<T>)
-    //.def_static("deserialize", &dspy::vo_union_deserialize<T>)
+    //.def("get_serialized_size_bytes", &var_opt_union<T>::get_serialized_size_bytes, py::arg("serde"),
+    //     "Computes the size in bytes needed to serialize the current sketch")
+    .def("serialize", &dspy::vo_union_serialize<T>, py::arg("serde"), "Serialize the var opt union using the provided serde")
+    .def_static("deserialize", &dspy::vo_union_deserialize<T>, py::arg("bytes"), py::arg("serde"),
+         "Constructs a var opt union from the given bytes using the provided serde")
     ;
 }
 

--- a/sampling/include/var_opt_sketch.hpp
+++ b/sampling/include/var_opt_sketch.hpp
@@ -305,8 +305,7 @@ class var_opt_sketch {
 
     friend class var_opt_union<T,S,A>;
     var_opt_sketch(const var_opt_sketch& other, bool as_sketch, uint64_t adjusted_n);
-    var_opt_sketch(T* data, double* weights, size_t len, uint32_t k, uint64_t n, uint32_t h_count, uint32_t r_count, double total_wt_r, const A& allocator);
-
+    
     string<A> items_to_string(bool print_gap) const;
 
     // internal-use-only update

--- a/sampling/include/var_opt_sketch_impl.hpp
+++ b/sampling/include/var_opt_sketch_impl.hpp
@@ -936,14 +936,8 @@ void var_opt_sketch<T,S,A>::decrease_k_by_1() {
     const uint32_t old_final_r_idx = (h_ + 1 + r_) - 1;
     if (old_final_r_idx != k_) throw std::logic_error("gadget in invalid state");
     
-    // need construct an item if gap has never been filled; copy target data into place to
-    // avoid an implicit requirement for a default constructor
-    // TODO: is this ok? can we run into problems with the copy?
-    if (!filled_data_) {
-      new (&data_[old_gap_idx]) T(data_[old_final_r_idx]);
-      filled_data_ = true;
-    }
     swap_values(old_final_r_idx, old_gap_idx);
+    filled_data_ = true; // we just filled the gap, and no need to check previous state
 
     // now we pull an item out of H; any item is ok, but if we grab the rightmost and then
     // reduce h_, the heap invariant will be preserved (and the gap will be restored), plus

--- a/sampling/include/var_opt_sketch_impl.hpp
+++ b/sampling/include/var_opt_sketch_impl.hpp
@@ -1704,7 +1704,7 @@ bool var_opt_sketch<T, S, A>::iterator::get_mark() const {
  */
 template<typename T, typename S, typename A>
 uint32_t var_opt_sketch<T,S,A>::get_adjusted_size(uint32_t max_size, uint32_t resize_target) {
-  if (max_size - (resize_target << 1) < 0L) {
+  if (max_size < (resize_target << 1)) {
     return max_size;
   }
   return resize_target;

--- a/sampling/include/var_opt_union.hpp
+++ b/sampling/include/var_opt_union.hpp
@@ -171,7 +171,6 @@ public:
    */
   string<A> to_string() const;
 
-
 private:
   typedef typename std::allocator_traits<A>::template rebind_alloc<var_opt_sketch<T,S,A>> AllocSketch;
 


### PR DESCRIPTION
The immediate result is for varopt, but having this working should be an important part of adding tuple support.

I'm least confident in the error recovery during deserialization. I think it's most likely that Python will throw an error which propagates through the c++ code. In this case I'm intercepting it to try to decrement reference counts for items we've already allocated but it's hard to tell if that's actually preventing a leak or not. Happy for suggestions on how to clean up that code.

Also, fixed a size bug in varopt.