### PR TITLE
Update  reverse_purge_hash_map copy constructor

### DIFF
--- a/fi/include/reverse_purge_hash_map_impl.hpp
+++ b/fi/include/reverse_purge_hash_map_impl.hpp
@@ -71,8 +71,8 @@ states_(nullptr)
       if (other.states_[i] > 0) {
         new (&keys_[i]) K(other.keys_[i]);
         values_[i] = other.values_[i];
+         if (--num == 0) break;
       }
-      if (--num == 0) break;
     }
   }
   std::copy(other.states_, other.states_ + size, states_);


### PR DESCRIPTION
I think reverse_purge_hash_map copy constructor should do this here, the original result is not being able to copy all the values. Or remove the if and copy all the values directly, but it may affect some performance