### PR TITLE
avoid needless call to memcpy with an empty entries_ array

### DIFF
--- a/theta/include/theta_sketch_impl.hpp
+++ b/theta/include/theta_sketch_impl.hpp
@@ -359,7 +359,7 @@ void compact_theta_sketch_alloc<A>::serialize(std::ostream& os) const {
   write(os, flags_byte);
   const uint16_t seed_hash = get_seed_hash();
   write(os, seed_hash);
-  if (!this->is_empty()) {
+  if (entries_.size() > 0) {
     if (!is_single_item) {
       const uint32_t num_entries = static_cast<uint32_t>(entries_.size());
       write(os, num_entries);
@@ -397,7 +397,7 @@ auto compact_theta_sketch_alloc<A>::serialize(unsigned header_size_bytes) const 
   ptr += copy_to_mem(flags_byte, ptr);
   const uint16_t seed_hash = get_seed_hash();
   ptr += copy_to_mem(seed_hash, ptr);
-  if (!this->is_empty()) {
+  if (entries_.size() > 0) {
     if (!is_single_item) {
       const uint32_t num_entries = static_cast<uint32_t>(entries_.size());
       ptr += copy_to_mem(num_entries, ptr);

--- a/tuple/include/tuple_sketch_impl.hpp
+++ b/tuple/include/tuple_sketch_impl.hpp
@@ -385,7 +385,7 @@ void compact_tuple_sketch<S, A>::serialize(std::ostream& os, const SerDe& sd) co
   write(os, flags_byte);
   const uint16_t seed_hash = get_seed_hash();
   write(os, seed_hash);
-  if (!this->is_empty()) {
+  if (entries_.size() > 0) {
     if (!is_single_item) {
       const uint32_t num_entries = static_cast<uint32_t>(entries_.size());
       write(os, num_entries);
@@ -430,7 +430,7 @@ auto compact_tuple_sketch<S, A>::serialize(unsigned header_size_bytes, const Ser
   ptr += copy_to_mem(flags_byte, ptr);
   const uint16_t seed_hash = get_seed_hash();
   ptr += copy_to_mem(seed_hash, ptr);
-  if (!this->is_empty()) {
+  if (entries_.size() > 0) {
     if (!is_single_item) {
       const uint32_t num_entries = static_cast<uint32_t>(entries_.size());
       ptr += copy_to_mem(num_entries, ptr);


### PR DESCRIPTION
Based on #300 , we should avoid calling memcpy() when entries_ is empty to keep -fsanitize=undefiend happy. The sanitizer (reasonably) detected a copy of 0 bytes from nullptr. And while that should be completely harmless in this case, it's cleaner to avoid entirely.