### PR TITLE
Update build_wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -62,12 +62,11 @@ jobs:
         with:
           python-version: '3.x'
            
-      #- name: Install Python dependencies
-      #  run: python -m pip install cibuildwheel==2.5.0
+      - name: Install Python dependencies
+        run: python -m pip install cibuildwheel==2.9.0
         
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.9.0
-        #run: python -m cibuildwheel --output-dir dist
+        run: python -m cibuildwheel --output-dir dist
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_BEFORE_BUILD: python -m pip install cmake>=3.18

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -37,22 +37,36 @@ jobs:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
     strategy:
-      fail-fast: false
+      #fail-fast: false
       matrix:
         config:
         - {
-            name: "MacOS 10.15",
-            os: macos-latest
+            name: "MacOS Latest (Intel)",
+            os: macos-latest,
+            cibw-arch: macosx_x86_64
           }
         - {
-            name: "Ubuntu Latest",
-            os: ubuntu-latest
+            name: "MacOS Latest (Apple Silicon)",
+            os: macos-latest,
+            cibw-arch: macosx_arm64
+          }
+        - {
+            name: "Ubuntu Latest (x86_64)",
+            os: ubuntu-latest,
+            cibw-arch: manylinux_x86_64
+          }
+        - {
+            name: "Ubuntu Latest (i686)",
+            os: ubuntu-latest,
+            cibw-arch: manylinux_i686
           }
         - {
             name: "Windows Latest",
-            os: windows-latest
+            os: windows-latest,
+            cibw-arch: win_amd64
           }
-            
+
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -63,15 +77,22 @@ jobs:
           python-version: '3.x'
            
       - name: Install Python dependencies
-        run: python -m pip install cibuildwheel==2.9.0
+        run: python -m pip install cibuildwheel==2.5.0
+        
+      - name: Configure cibuildwheel
+        shell: bash
+        run: |
+          CMAKE_OSX_ARCHITECTURES=${{ matrix.cibw-arch == 'macosx_x86_64' && 'x86_64' || matrix.cibw-arch == 'macosx_arm64' && 'arm64' || matrix.cibw-arch == 'macosx_universal2' && '"arm64;x86_64"' || '' }}
+          echo "CIBW_ARCHS_MACOS=x86_64 arm64" >> $GITHUB_ENV
+          echo "CIBW_BUILD=*-${{ matrix.cibw-arch }}" >> $GITHUB_ENV
+          echo "CIBW_ENVIRONMENT_MACOS=CMAKE_OSX_ARCHITECTURES=\"$CMAKE_OSX_ARCHITECTURES\"" >> $GITHUB_ENV
         
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist
         env:
-          MACOSX_DEPLOYMENT_TARGET: 10.15
+          CIBW_BEFORE_BUILD_LINUX: "yum remove -y cmake"
           CIBW_BEFORE_BUILD: python -m pip install cmake>=3.18
           CIBW_SKIP: "*-win32 pp*-macosx*"
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -62,15 +62,17 @@ jobs:
         with:
           python-version: '3.x'
            
-      - name: Install Python dependencies
-        run: python -m pip install cibuildwheel==2.5.0
+      #- name: Install Python dependencies
+      #  run: python -m pip install cibuildwheel==2.5.0
         
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir dist
+        uses: pypa/cibuildwheel@v2.9.0
+        #run: python -m cibuildwheel --output-dir dist
         env:
+          MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_BEFORE_BUILD: python -m pip install cmake>=3.18
           CIBW_SKIP: "*-win32 pp*-macosx*"
-          CIBW_ARCHS_MACOS: "x86_64 arm64 universal2"
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -82,16 +82,16 @@ jobs:
       - name: Configure cibuildwheel
         shell: bash
         run: |
-          CMAKE_OSX_ARCHITECTURES=${{ matrix.cibw-arch == 'macosx_x86_64' && 'x86_64' || matrix.cibw-arch == 'macosx_arm64' && 'arm64' || matrix.cibw-arch == 'macosx_universal2' && '"arm64;x86_64"' || '' }}
+          CMAKE_OSX_ARCHITECTURES=${{ matrix.config.cibw-arch == 'macosx_x86_64' && 'x86_64' || matrix.config.cibw-arch == 'macosx_arm64' && 'arm64' || matrix.config.cibw-arch == 'macosx_universal2' && '"arm64;x86_64"' || '' }}
           echo "CIBW_ARCHS_MACOS=x86_64 arm64" >> $GITHUB_ENV
-          echo "CIBW_BUILD=*-${{ matrix.cibw-arch }}" >> $GITHUB_ENV
+          echo "CIBW_BUILD=*-${{ matrix.config.cibw-arch }}" >> $GITHUB_ENV
           echo "CIBW_ENVIRONMENT_MACOS=CMAKE_OSX_ARCHITECTURES=\"$CMAKE_OSX_ARCHITECTURES\"" >> $GITHUB_ENV
         
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist
         env:
           CIBW_BEFORE_BUILD_LINUX: "yum remove -y cmake"
-          CIBW_BEFORE_BUILD: python -m pip install cmake>=3.18
+          CIBW_BEFORE_BUILD: "python -m pip install cmake>=3.18"
           CIBW_SKIP: "*-win32 pp*-macosx*"
 
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
Sets cmake environment variables to fix build problems for Apple Silicon (aka arm64) devices. Previously, the CI task knew the build for both Intel and ARM instruction sets, but cmake was detecting the platform (Intel) and always using that. As a result, the underlying C++ library was never actually cross-compiled for the target platform.

This should (finally) fix the python library for non-Intel Macs.