### PR TITLE
Fix broken links to reference Java files from before move to Apache.

### DIFF
--- a/fi/include/frequent_items_sketch.hpp
+++ b/fi/include/frequent_items_sketch.hpp
@@ -34,7 +34,7 @@ namespace datasketches {
 
 /*
  * Based on Java implementation here:
- * https://github.com/DataSketches/sketches-core/blob/master/src/main/java/com/yahoo/sketches/frequencies/ItemsSketch.java
+ * https://github.com/apache/datasketches-java/blob/master/src/main/java/org/apache/datasketches/frequencies/ItemsSketch.java
  * author Alexander Saydakov
  */
 

--- a/fi/include/reverse_purge_hash_map.hpp
+++ b/fi/include/reverse_purge_hash_map.hpp
@@ -29,7 +29,7 @@ namespace datasketches {
  * This is a specialized linear-probing hash map with a reverse purge operation
  * that removes all entries in the map with values that are less than zero.
  * Based on Java implementation here:
- * https://github.com/DataSketches/sketches-core/blob/master/src/main/java/com/yahoo/sketches/frequencies/ReversePurgeItemHashMap.java
+ * https://github.com/apache/datasketches-java/blob/master/src/main/java/org/apache/datasketches/frequencies/ReversePurgeItemHashMap.java
  * author Alexander Saydakov
  */
 


### PR DESCRIPTION
Noticed a couple broken links in the header documentation.  Small patch to update.