### PR TITLE
Remove write-only variables

### DIFF
--- a/sampling/include/var_opt_sketch_impl.hpp
+++ b/sampling/include/var_opt_sketch_impl.hpp
@@ -754,10 +754,10 @@ string<A> var_opt_sketch<T, A>::items_to_string(bool print_gap) const {
   const uint32_t array_length = (n_ < k_ ? n_ : k_ + 1);
   for (uint32_t i = 0, display_idx = 0; i < array_length; ++i) {
     if (i == h_ && print_gap) {
-      os << i << ": GAP" << std::endl;
+      os << display_idx << ": GAP" << std::endl;
       ++display_idx;
     } else {
-      os << i << ": " << data_[i] << "\twt = ";
+      os << display_idx << ": " << data_[i] << "\twt = ";
       if (weights_[i] == -1.0) {
         os << get_tau() << "\t(-1.0)" << std::endl;
       } else {

--- a/sampling/test/var_opt_sketch_test.cpp
+++ b/sampling/test/var_opt_sketch_test.cpp
@@ -55,14 +55,12 @@ static void check_if_equal(var_opt_sketch<T, A>& sk1, var_opt_sketch<T, A>& sk2)
       
   auto it1 = sk1.begin();
   auto it2 = sk2.begin();
-  size_t i = 0;
 
   while ((it1 != sk1.end()) && (it2 != sk2.end())) {
     auto p1 = *it1;
     auto p2 = *it2;
     REQUIRE(p1.first == p2.first);   // data values
     REQUIRE(p1.second == p2.second); // weights
-    ++i;
     ++it1;
     ++it2;
   }

--- a/sampling/test/var_opt_union_test.cpp
+++ b/sampling/test/var_opt_union_test.cpp
@@ -57,7 +57,6 @@ static void check_if_equal(var_opt_sketch<T, A>& sk1, var_opt_sketch<T, A>& sk2,
       
   auto it1 = sk1.begin();
   auto it2 = sk2.begin();
-  size_t i = 0;
 
   while ((it1 != sk1.end()) && (it2 != sk2.end())) {
     const std::pair<const T&, const double> p1 = *it1;
@@ -66,7 +65,6 @@ static void check_if_equal(var_opt_sketch<T, A>& sk1, var_opt_sketch<T, A>& sk2,
       REQUIRE(p1.first == p2.first); // data values
     }
     REQUIRE(p1.second == p2.second); // weight values
-    ++i;
     ++it1;
     ++it2;
   }


### PR DESCRIPTION
These variables were never read, which causes warning when compiling with clang 16