### PR TITLE
Include header implicitly used

### DIFF
--- a/theta/include/theta_helpers.hpp
+++ b/theta/include/theta_helpers.hpp
@@ -20,8 +20,10 @@
 #ifndef THETA_HELPERS_HPP_
 #define THETA_HELPERS_HPP_
 
-#include <string>
 #include <stdexcept>
+#include <string>
+
+#include "theta_constants.hpp"
 
 namespace datasketches {
 


### PR DESCRIPTION
theta_helpers.hpp uses theta_constants::MAX_THETA, which is declared in theta_constants.hpp. This patch #includes it as well as alphabetizes the standard headers.