### PR TITLE
Explicitly cast constant uint64_ts that lose precision.

### DIFF
--- a/theta/include/theta_helpers.hpp
+++ b/theta/include/theta_helpers.hpp
@@ -55,7 +55,7 @@ public:
   // consistent way of initializing theta from p
   // avoids multiplication if p == 1 since it might not yield MAX_THETA exactly
   static uint64_t starting_theta_from_p(float p) {
-    if (p < 1) return static_cast<uint64_t>(theta_constants::MAX_THETA * p);
+    if (p < 1) return static_cast<float>(theta_constants::MAX_THETA) * p;
     return theta_constants::MAX_THETA;
   }
 

--- a/theta/include/theta_sketch_impl.hpp
+++ b/theta/include/theta_sketch_impl.hpp
@@ -38,7 +38,8 @@ bool base_theta_sketch_alloc<A>::is_estimation_mode() const {
 
 template<typename A>
 double base_theta_sketch_alloc<A>::get_theta() const {
-  return static_cast<double>(get_theta64()) / theta_constants::MAX_THETA;
+  return static_cast<double>(get_theta64()) /
+         static_cast<double>(theta_constants::MAX_THETA);
 }
 
 template<typename A>

--- a/tuple/include/tuple_sketch_impl.hpp
+++ b/tuple/include/tuple_sketch_impl.hpp
@@ -32,7 +32,8 @@ bool tuple_sketch<S, A>::is_estimation_mode() const {
 
 template<typename S, typename A>
 double tuple_sketch<S, A>::get_theta() const {
-  return static_cast<double>(get_theta64()) / theta_constants::MAX_THETA;
+  return static_cast<double>(get_theta64()) /
+         static_cast<double>(theta_constants::MAX_THETA);
 }
 
 template<typename S, typename A>


### PR DESCRIPTION
In clang-16, there are warnings like this upon build:

    warning: implicit conversion from 'const uint64_t' (aka 'const
    unsigned long') to 'double' changes value from 9223372036854775807
    to 9223372036854775808 [-Wimplicit-const-int-float-conversion]

Explicit casting fixes those warnings.