### PR TITLE
Python tuple sketch support

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(python
     cpc
     fi
     theta
+    tuple
     sampling
     req
     quantiles
@@ -72,6 +73,7 @@ target_sources(python
     src/cpc_wrapper.cpp
     src/fi_wrapper.cpp
     src/theta_wrapper.cpp
+    src/tuple_wrapper.cpp
     src/vo_wrapper.cpp
     src/req_wrapper.cpp
     src/quantiles_wrapper.cpp

--- a/python/datasketches/PySerDe.py
+++ b/python/datasketches/PySerDe.py
@@ -54,51 +54,57 @@ class PyStringsSerDe(PyObjectSerDe):
     str = data[offset+4:offset+4+num_chars].decode()
     return (str, 4+num_chars)
 
-# Implements an integer-encoding scheme where each integer is written
+# Implements an integer encoding scheme where each integer is written
 # as a 32-bit (4 byte) little-endian value.
 class PyIntsSerDe(PyObjectSerDe):
   def get_size(self, item):
     return int(4)
 
   def to_bytes(self, item):
-    return struct.pack('i', item)
+    return struct.pack('<i', item)
 
   def from_bytes(self, data: bytes, offset: int):
-    val = struct.unpack_from('i', data, offset)[0]
+    val = struct.unpack_from('<i', data, offset)[0]
     return (val, 4)
 
 
+# Implements an integer encoding scheme where each integer is written
+# as a 64-bit (8 byte) little-endian value.
 class PyLongsSerDe(PyObjectSerDe):
   def get_size(self, item):
     return int(8)
 
   def to_bytes(self, item):
-    return struct.pack('l', item)
+    return struct.pack('<l', item)
 
   def from_bytes(self, data: bytes, offset: int):
-    val = struct.unpack_from('l', data, offset)[0]
+    val = struct.unpack_from('<l', data, offset)[0]
     return (val, 8)
 
 
+# Implements a floating point encoding scheme where each value is written
+# as a 32-bit floating point value.
 class PyFloatsSerDe(PyObjectSerDe):
   def get_size(self, item):
     return int(4)
 
   def to_bytes(self, item):
-    return struct.pack('f', item)
+    return struct.pack('<f', item)
 
   def from_bytes(self, data: bytes, offset: int):
-    val = struct.unpack_from('f', data, offset)[0]
+    val = struct.unpack_from('<f', data, offset)[0]
     return (val, 4)
 
 
+# Implements a floating point encoding scheme where each value is written
+# as a 64-bit floating point value.
 class PyDoublesSerDe(PyObjectSerDe):
   def get_size(self, item):
     return int(8)
 
   def to_bytes(self, item):
-    return struct.pack('d', item)
+    return struct.pack('<d', item)
 
   def from_bytes(self, data: bytes, offset: int):
-    val = struct.unpack_from('d', data, offset)[0]
+    val = struct.unpack_from('<d', data, offset)[0]
     return (val, 8)

--- a/python/datasketches/TuplePolicy.py
+++ b/python/datasketches/TuplePolicy.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import sys
+
 from _datasketches import TuplePolicy
 
 # This file provides an example Python Tuple Policy implementation.
@@ -25,7 +27,7 @@ from _datasketches import TuplePolicy
 #   * update_summary(summary, update) applies the relevant policy to update the
 #     provided summary with the data in update.
 #   * __call__ may be similar to update_summary but allows a different
-#     implementation for set operations
+#     implementation for set operations (union and intersection)
 
 # Implements an accumulator summary policy, where new values are
 # added to the existing value.
@@ -43,3 +45,48 @@ class AccumulatorPolicy(TuplePolicy):
   def __call__(self, summary: int, update: int) -> int:
     summary += update
     return summary
+
+
+# Implements a MAX rule, where the largest integer value is always kept
+class MaxIntPolicy(TuplePolicy):
+  def __init__(self):
+    TuplePolicy.__init__(self)
+
+  def create_summary(self) -> int:
+    return int(-sys.maxsize-1)
+
+  def update_summary(self, summary: int, update: int) -> int:
+    return max(summary, update)
+
+  def __call__(self, summary: int, update: int) -> int:
+    return max(summary, update)
+
+
+# Implements a MIN rule, where the smallest integer value is always kept
+class MinIntPolicy(TuplePolicy):
+  def __init__(self):
+    TuplePolicy.__init__(self)
+
+  def create_summary(self) -> int:
+    return int(sys.maxsize)
+
+  def update_summary(self, summary: int, update: int) -> int:
+    return min(summary, update)
+
+  def __call__(self, summary: int, update: int) -> int:
+    return min(summary, update)
+
+
+# Implements an Always One policy, where the summary is always exactly 1
+class AkwaysOnePolicy(TuplePolicy):
+  def __init__(self):
+    TuplePolicy.__init__(self)
+
+  def create_summary(self) -> int:
+    return int(1)
+
+  def update_summary(self, summary: int, update: int) -> int:
+    return int(1)
+
+  def __call__(self, summary: int, update: int) -> int:
+    return int(1)

--- a/python/datasketches/TuplePolicy.py
+++ b/python/datasketches/TuplePolicy.py
@@ -21,19 +21,25 @@ from _datasketches import TuplePolicy
 #
 # Each implementation must extend the PyTuplePolicy class and define
 # two methods:
-#   * create() returns a new Summary object
-#   * update(summary, update) applies the relevant policy to update the
+#   * create_summary() returns a new Summary object
+#   * update_summary(summary, update) applies the relevant policy to update the
 #     provided summary with the data in update.
+#   * __call__ may be similar to update_summary but allows a different
+#     implementation for set operations
 
 # Implements an accumulator summary policy, where new values are
 # added to the existing value.
-class AccumulatorUpdatePolicy(TuplePolicy):
+class AccumulatorPolicy(TuplePolicy):
   def __init__(self):
     TuplePolicy.__init__(self)
 
-  def create_summary(self):
+  def create_summary(self) -> int:
     return int(0)
 
-  def update_summary(self, summary: int, update: int):
+  def update_summary(self, summary: int, update: int) -> int:
+    summary += update
+    return summary
+
+  def __call__(self, summary: int, update: int) -> int:
     summary += update
     return summary

--- a/python/datasketches/TuplePolicy.py
+++ b/python/datasketches/TuplePolicy.py
@@ -15,9 +15,25 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name = 'datasketches'
+from _datasketches import TuplePolicy
 
-from .PySerDe import *
-from .TuplePolicy import *
+# This file provides an example Python Tuple Policy implementation.
+#
+# Each implementation must extend the PyTuplePolicy class and define
+# two methods:
+#   * create() returns a new Summary object
+#   * update(summary, update) applies the relevant policy to update the
+#     provided summary with the data in update.
 
-from _datasketches import *
+# Implements an accumulator summary policy, where new values are
+# added to the existing value.
+class AccumulatorUpdatePolicy(TuplePolicy):
+  def __init__(self):
+    TuplePolicy.__init__(self)
+
+  def create_summary(self):
+    return int(0)
+
+  def update_summary(self, summary: int, update: int):
+    summary += update
+    return summary

--- a/python/src/datasketches.cpp
+++ b/python/src/datasketches.cpp
@@ -27,6 +27,7 @@ void init_kll(py::module& m);
 void init_fi(py::module& m);
 void init_cpc(py::module& m);
 void init_theta(py::module& m);
+void init_tuple(py::module& m);
 void init_vo(py::module& m);
 void init_req(py::module& m);
 void init_quantiles(py::module& m);
@@ -42,6 +43,7 @@ PYBIND11_MODULE(_datasketches, m) {
   init_fi(m);
   init_cpc(m);
   init_theta(m);
+  init_tuple(m);
   init_vo(m);
   init_req(m);
   init_quantiles(m);

--- a/python/src/py_serde.cpp
+++ b/python/src/py_serde.cpp
@@ -27,13 +27,14 @@
 namespace py = pybind11;
 
 void init_serde(py::module& m) {
-  py::class_<datasketches::py_object_serde, datasketches::PyObjectSerDe /* <--- trampoline*/>(m, "PyObjectSerDe")
+  using namespace datasketches;
+  py::class_<py_object_serde, PyObjectSerDe /* <--- trampoline*/>(m, "PyObjectSerDe")
     .def(py::init<>())
-    .def("get_size", &datasketches::py_object_serde::get_size, py::arg("item"),
+    .def("get_size", &py_object_serde::get_size, py::arg("item"),
         "Returns the size in bytes of an item")
-    .def("to_bytes", &datasketches::py_object_serde::to_bytes, py::arg("item"),
+    .def("to_bytes", &py_object_serde::to_bytes, py::arg("item"),
         "Retuns a bytes object with a serialized version of an item")
-    .def("from_bytes", &datasketches::py_object_serde::from_bytes, py::arg("data"), py::arg("offset"),
+    .def("from_bytes", &py_object_serde::from_bytes, py::arg("data"), py::arg("offset"),
         "Reads a bytes object starting from the given offest and returns a tuple of the reconstructed "
         "object and the number of additional bytes read")
     ;

--- a/python/src/theta_wrapper.cpp
+++ b/python/src/theta_wrapper.cpp
@@ -128,7 +128,7 @@ void init_theta(py::module &m) {
         "compute",
         &theta_a_not_b::compute<const theta_sketch&, const theta_sketch&>,
         py::arg("a"), py::arg("b"), py::arg("ordered")=true,
-        "Returns a sketch with the reuslt of appying the A-not-B operation on the given inputs"
+        "Returns a sketch with the result of appying the A-not-B operation on the given inputs"
     )
   ;
   

--- a/python/src/tuple_wrapper.cpp
+++ b/python/src/tuple_wrapper.cpp
@@ -25,7 +25,7 @@
 #include "tuple_union.hpp"
 #include "tuple_intersection.hpp"
 #include "tuple_a_not_b.hpp"
-#include "tuple_jaccard_similarity.hpp"
+#include "theta_jaccard_similarity_base.hpp"
 #include "common_defs.hpp"
 
 #include "py_serde.hpp"
@@ -95,6 +95,12 @@ struct tuple_policy_holder {
     std::shared_ptr<tuple_policy> _policy;
 };
 
+struct dummy_jaccard_policy {
+  void operator()(py::object&, const py::object&) const {
+    return;
+  }
+};
+
 }
 
 void init_tuple(py::module &m) {
@@ -124,6 +130,7 @@ void init_tuple(py::module &m) {
   using py_tuple_union = tuple_union<py::object, tuple_policy_holder>;
   using py_tuple_intersection = tuple_intersection<py::object, tuple_policy_holder>;
   using py_tuple_a_not_b = tuple_a_not_b<py::object>;
+  using py_tuple_jaccard_similarity = jaccard_similarity_base<tuple_union<py::object, dummy_jaccard_policy>, tuple_intersection<py::object, dummy_jaccard_policy>, pair_extract_key<uint64_t, py::object>>;
 
   py::class_<py_tuple_sketch>(m, "tuple_sketch")
     .def("__str__", &py_tuple_sketch::to_string, py::arg("print_items")=false,
@@ -236,8 +243,7 @@ void init_tuple(py::module &m) {
     )
   ;
 
-  /*
-  py::class_<py_tuple_jaccard_similarity>(m, "theta_jaccard_similarity")
+  py::class_<py_tuple_jaccard_similarity>(m, "tuple_jaccard_similarity")
     .def_static(
         "jaccard",
         [](const py_tuple_sketch& sketch_a, const py_tuple_sketch& sketch_b, uint64_t seed) {
@@ -268,5 +274,4 @@ void init_tuple(py::module &m) {
         "to be dissimilar sith a confidence of 97.7% and returns True, otherwise False."
     )
   ;
-  */
 }

--- a/python/src/tuple_wrapper.cpp
+++ b/python/src/tuple_wrapper.cpp
@@ -232,7 +232,7 @@ void init_tuple(py::module &m) {
         "compute",
         &py_tuple_a_not_b::compute<const py_tuple_sketch&, const py_tuple_sketch&>,
         py::arg("a"), py::arg("b"), py::arg("ordered")=true,
-        "Returns a sketch with the reuslt of appying the A-not-B operation on the given inputs"
+        "Returns a sketch with the result of appying the A-not-B operation on the given inputs"
     )
   ;
 

--- a/python/src/tuple_wrapper.cpp
+++ b/python/src/tuple_wrapper.cpp
@@ -118,41 +118,44 @@ void init_tuple(py::module &m) {
          "Updates the provided summary using the data in update")
   ;
 
-  using py_tuple = tuple_sketch<py::object>;
+  using py_tuple_sketch = tuple_sketch<py::object>;
   using py_update_tuple = update_tuple_sketch<py::object, py::object, tuple_policy_holder>;
   using py_compact_tuple = compact_tuple_sketch<py::object>;
+  using py_tuple_union = tuple_union<py::object, tuple_policy_holder>;
+  using py_tuple_intersection = tuple_intersection<py::object, tuple_policy_holder>;
+  using py_tuple_a_not_b = tuple_a_not_b<py::object>;
 
-  py::class_<py_tuple>(m, "tuple_sketch")
-    .def("__str__", &py_tuple::to_string, py::arg("print_items")=false,
+  py::class_<py_tuple_sketch>(m, "tuple_sketch")
+    .def("__str__", &py_tuple_sketch::to_string, py::arg("print_items")=false,
          "Produces a string summary of the sketch")
-    .def("to_string", &py_tuple::to_string, py::arg("print_items")=false,
+    .def("to_string", &py_tuple_sketch::to_string, py::arg("print_items")=false,
          "Produces a string summary of the sketch")
-    .def("is_empty", &py_tuple::is_empty,
+    .def("is_empty", &py_tuple_sketch::is_empty,
          "Returns True if the sketch is empty, otherwise False")
-    .def("get_estimate", &py_tuple::get_estimate,
+    .def("get_estimate", &py_tuple_sketch::get_estimate,
          "Estimate of the distinct count of the input stream")
-    .def("get_upper_bound", static_cast<double (py_tuple::*)(uint8_t) const>(&py_tuple::get_upper_bound), py::arg("num_std_devs"),
+    .def("get_upper_bound", static_cast<double (py_tuple_sketch::*)(uint8_t) const>(&py_tuple_sketch::get_upper_bound), py::arg("num_std_devs"),
          "Returns an approximate upper bound on the estimate at standard deviations in {1, 2, 3}")
-    .def("get_lower_bound", static_cast<double (py_tuple::*)(uint8_t) const>(&py_tuple::get_lower_bound), py::arg("num_std_devs"),
+    .def("get_lower_bound", static_cast<double (py_tuple_sketch::*)(uint8_t) const>(&py_tuple_sketch::get_lower_bound), py::arg("num_std_devs"),
          "Returns an approximate lower bound on the estimate at standard deviations in {1, 2, 3}")
-    .def("is_estimation_mode", &py_tuple::is_estimation_mode,
+    .def("is_estimation_mode", &py_tuple_sketch::is_estimation_mode,
          "Returns True if sketch is in estimation mode, otherwise False")
-    .def("get_theta", &py_tuple::get_theta,
+    .def("get_theta", &py_tuple_sketch::get_theta,
          "Returns theta (effective sampling rate) as a fraction from 0 to 1")
-    .def("get_theta64", &py_tuple::get_theta64,
+    .def("get_theta64", &py_tuple_sketch::get_theta64,
          "Returns theta as 64-bit value")
-    .def("get_num_retained", &py_tuple::get_num_retained,
+    .def("get_num_retained", &py_tuple_sketch::get_num_retained,
          "Retunrs the number of items currently in the sketch")
-    .def("get_seed_hash", [](const py_tuple& sk) { return sk.get_seed_hash(); }, // why does regular call not work??
+    .def("get_seed_hash", [](const py_tuple_sketch& sk) { return sk.get_seed_hash(); }, // why does regular call not work??
          "Returns a hash of the seed used in the sketch")
-    .def("is_ordered", &py_tuple::is_ordered,
+    .def("is_ordered", &py_tuple_sketch::is_ordered,
          "Returns True if the sketch entries are sorted, otherwise False")
-    .def("__iter__", [](const py_tuple& s) { return py::make_iterator(s.begin(), s.end()); })
+    .def("__iter__", [](const py_tuple_sketch& s) { return py::make_iterator(s.begin(), s.end()); })
   ;
 
-  py::class_<py_compact_tuple, py_tuple>(m, "compact_tuple_sketch")
+  py::class_<py_compact_tuple, py_tuple_sketch>(m, "compact_tuple_sketch")
     .def(py::init<const py_compact_tuple&>())
-    .def(py::init<const py_tuple&, bool>())
+    .def(py::init<const py_tuple_sketch&, bool>())
     .def(
         "serialize",
         [](const py_compact_tuple& sk, py_object_serde& serde) {
@@ -170,7 +173,7 @@ void init_tuple(py::module &m) {
         "Reads a bytes object and returns the corresponding compact_tuple_sketch"
     );
 
-  py::class_<py_update_tuple, py_tuple>(m, "update_tuple_sketch")
+  py::class_<py_update_tuple, py_tuple_sketch>(m, "update_tuple_sketch")
     .def(
         py::init([](uint8_t lg_k, std::shared_ptr<tuple_policy> policy, double p, uint64_t seed) {
           tuple_policy_holder holder(policy);
@@ -179,79 +182,86 @@ void init_tuple(py::module &m) {
         py::arg("lg_k")=theta_constants::DEFAULT_LG_K, py::arg("policy"), py::arg("p")=1.0, py::arg("seed")=DEFAULT_SEED
     )
     .def(py::init<const py_update_tuple&>())
-    .def("update", (void (py_update_tuple::*)(int64_t, py::object&)) &py_update_tuple::update,
+    .def("update", static_cast<void (py_update_tuple::*)(int64_t, py::object&)>(&py_update_tuple::update),
          py::arg("datum"), py::arg("summary"),
          "Updates the sketch with the given integral value")
-    .def("update", (void (py_update_tuple::*)(double, py::object&)) &py_update_tuple::update,
+    .def("update", static_cast<void (py_update_tuple::*)(double, py::object&)>(&py_update_tuple::update),
          py::arg("datum"), py::arg("summary"),
          "Updates the sketch with the given floating point value")
-    .def("update", (void (py_update_tuple::*)(const std::string&, py::object&)) &py_update_tuple::update,
+    .def("update", static_cast<void (py_update_tuple::*)(const std::string&, py::object&)>(&py_update_tuple::update),
          py::arg("datum"), py::arg("summary"),
          "Updates the sketch with the given string")
     .def("compact", &py_update_tuple::compact, py::arg("ordered")=true,
          "Returns a compacted form of the sketch, optionally sorting it")
   ;
 
-/*
-  py::class_<theta_union>(m, "theta_union")
+  py::class_<py_tuple_union>(m, "tuple_union")
     .def(
-        py::init([](uint8_t lg_k, double p, uint64_t seed) {
-          return theta_union::builder().set_lg_k(lg_k).set_p(p).set_seed(seed).build();
+        py::init([](uint8_t lg_k, std::shared_ptr<tuple_policy> policy, double p, uint64_t seed) {
+          tuple_policy_holder holder(policy);
+          return py_tuple_union::builder(holder).set_lg_k(lg_k).set_p(p).set_seed(seed).build();
         }),
-        py::arg("lg_k")=theta_constants::DEFAULT_LG_K, py::arg("p")=1.0, py::arg("seed")=DEFAULT_SEED
+        py::arg("lg_k")=theta_constants::DEFAULT_LG_K, py::arg("policy"), py::arg("p")=1.0, py::arg("seed")=DEFAULT_SEED
     )
-    .def("update", &theta_union::update<const theta_sketch&>, py::arg("sketch"),
+    .def("update", &py_tuple_union::update<const py_tuple_sketch&>, py::arg("sketch"),
          "Updates the union with the given sketch")
-    .def("get_result", &theta_union::get_result, py::arg("ordered")=true,
+    .def("get_result", &py_tuple_union::get_result, py::arg("ordered")=true,
          "Returns the sketch corresponding to the union result")
+    .def("reset", &py_tuple_union::reset,
+         "Resets the sketch to the initial empty")
   ;
 
-  py::class_<theta_intersection>(m, "theta_intersection")
-    .def(py::init<uint64_t>(), py::arg("seed")=DEFAULT_SEED)
-    .def(py::init<const theta_intersection&>())
-    .def("update", &theta_intersection::update<const theta_sketch&>, py::arg("sketch"),
+  py::class_<py_tuple_intersection>(m, "tuple_intersection")
+    .def(
+        py::init([](uint64_t seed, std::shared_ptr<tuple_policy> policy) {
+          tuple_policy_holder holder(policy);
+          return py_tuple_intersection(seed, holder);
+        }),
+        py::arg("seed")=DEFAULT_SEED, py::arg("policy"))
+    .def("update", &py_tuple_intersection::update<const py_tuple_sketch&>, py::arg("sketch"),
          "Intersections the provided sketch with the current intersection state")
-    .def("get_result", &theta_intersection::get_result, py::arg("ordered")=true,
+    .def("get_result", &py_tuple_intersection::get_result, py::arg("ordered")=true,
          "Returns the sketch corresponding to the intersection result")
-    .def("has_result", &theta_intersection::has_result,
+    .def("has_result", &py_tuple_intersection::has_result,
          "Returns True if the intersection has a valid result, otherwise False")
   ;
 
-  py::class_<theta_a_not_b>(m, "theta_a_not_b")
+  py::class_<py_tuple_a_not_b>(m, "tuple_a_not_b")
     .def(py::init<uint64_t>(), py::arg("seed")=DEFAULT_SEED)
     .def(
         "compute",
-        &theta_a_not_b::compute<const theta_sketch&, const theta_sketch&>,
+        &py_tuple_a_not_b::compute<const py_tuple_sketch&, const py_tuple_sketch&>,
         py::arg("a"), py::arg("b"), py::arg("ordered")=true,
         "Returns a sketch with the reuslt of appying the A-not-B operation on the given inputs"
     )
   ;
-  
-  py::class_<theta_jaccard_similarity>(m, "theta_jaccard_similarity")
+
+  /*
+  py::class_<py_tuple_jaccard_similarity>(m, "theta_jaccard_similarity")
     .def_static(
         "jaccard",
-        [](const theta_sketch& sketch_a, const theta_sketch& sketch_b, uint64_t seed) {
-          return theta_jaccard_similarity::jaccard(sketch_a, sketch_b, seed);
+        [](const py_tuple_sketch& sketch_a, const py_tuple_sketch& sketch_b, uint64_t seed) {
+          return py_tuple_jaccard_similarity::jaccard(sketch_a, sketch_b, seed);
         },
         py::arg("sketch_a"), py::arg("sketch_b"), py::arg("seed")=DEFAULT_SEED,
         "Returns a list with {lower_bound, estimate, upper_bound} of the Jaccard similarity between sketches"
     )
     .def_static(
         "exactly_equal",
-        &theta_jaccard_similarity::exactly_equal<const theta_sketch&, const theta_sketch&>,
+        &py_tuple_jaccard_similarity::exactly_equal<const py_tuple_sketch&, const py_tuple_sketch&>,
         py::arg("sketch_a"), py::arg("sketch_b"), py::arg("seed")=DEFAULT_SEED,
         "Returns True if sketch_a and sketch_b are equivalent, otherwise False"
     )
     .def_static(
         "similarity_test",
-        &theta_jaccard_similarity::similarity_test<const theta_sketch&, const theta_sketch&>,
+        &py_tuple_jaccard_similarity::similarity_test<const py_tuple_sketch&, const py_tuple_sketch&>,
         py::arg("actual"), py::arg("expected"), py::arg("threshold"), py::arg("seed")=DEFAULT_SEED,
         "Tests similarity of an actual sketch against an expected sketch. Computers the lower bound of the Jaccard "
         "index J_{LB} of the actual and expected sketches. If J_{LB} >= threshold, then the sketches are considered "
         "to be similar sith a confidence of 97.7% and returns True, otherwise False.")
     .def_static(
         "dissimilarity_test",
-        &theta_jaccard_similarity::dissimilarity_test<const theta_sketch&, const theta_sketch&>,
+        &py_tuple_jaccard_similarity::dissimilarity_test<const py_tuple_sketch&, const py_tuple_sketch&>,
         py::arg("actual"), py::arg("expected"), py::arg("threshold"), py::arg("seed")=DEFAULT_SEED,
         "Tests dissimilarity of an actual sketch against an expected sketch. Computers the lower bound of the Jaccard "
         "index J_{UB} of the actual and expected sketches. If J_{UB} <= threshold, then the sketches are considered "

--- a/python/src/tuple_wrapper.cpp
+++ b/python/src/tuple_wrapper.cpp
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <memory>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "tuple_sketch.hpp"
+#include "tuple_union.hpp"
+#include "tuple_intersection.hpp"
+#include "tuple_a_not_b.hpp"
+#include "tuple_jaccard_similarity.hpp"
+#include "common_defs.hpp"
+
+#include "py_serde.hpp"
+
+namespace py = pybind11;
+
+namespace datasketches {
+
+struct tuple_policy {
+  virtual py::object create_summary() const = 0;
+  virtual py::object update_summary(py::object& summary, const py::object& update) const = 0;
+  virtual ~tuple_policy() = default;
+};
+
+struct TuplePolicy : public tuple_policy {
+  using tuple_policy::tuple_policy;
+
+  // trampoline definitions -- need one for each virtual function
+  py::object create_summary() const override {
+    PYBIND11_OVERRIDE_PURE(
+      py::object,          // Return type
+      tuple_policy,        // Parent class
+      create_summary,      // Name of function in C++ (must match Python name)
+                           // Argument(s) -- if any
+    );
+  }
+
+  py::object update_summary(py::object& summary, const py::object& update) const override {
+    PYBIND11_OVERRIDE_PURE(
+      py::object,          // Return type
+      tuple_policy,        // Parent class
+      update_summary,      // Name of function in C++ (must match Python name)
+      summary, update      // Argument(s)
+    );
+  }
+};
+
+struct tuple_policy_holder {
+  explicit tuple_policy_holder(std::shared_ptr<tuple_policy> policy) : _policy(policy) {}
+  tuple_policy_holder(const tuple_policy_holder& other) : _policy(other._policy) {}
+  tuple_policy_holder(tuple_policy_holder&& other) : _policy(std::move(other._policy)) {}
+  tuple_policy_holder& operator=(const tuple_policy_holder& other) { _policy = other._policy; return *this; }
+  tuple_policy_holder& operator=(tuple_policy_holder&& other) { std::swap(_policy, other._policy); return *this; }
+
+  py::object create() const { return _policy->create_summary(); }
+  
+  void update(py::object& summary, const py::object& update) const {
+    summary = _policy->update_summary(summary, update);
+  }
+
+  private:
+    std::shared_ptr<tuple_policy> _policy;
+};
+
+}
+
+void init_tuple(py::module &m) {
+  using namespace datasketches;
+
+  py::class_<tuple_policy, TuplePolicy, std::shared_ptr<tuple_policy>>(m, "TuplePolicy")
+    .def(py::init())
+    .def("create_summary", &tuple_policy::create_summary)
+    .def("update_summary", &tuple_policy::update_summary, py::arg("summary"), py::arg("update"))
+  ;
+
+  // only needed temporarily -- can remove once everything is working
+  py::class_<tuple_policy_holder>(m, "TuplePolicyHolder")
+    .def(py::init<std::shared_ptr<tuple_policy>>())
+    .def("create", &tuple_policy_holder::create, "Creates a new Summary object")
+    .def("update", &tuple_policy_holder::update, py::arg("summary"), py::arg("update"),
+         "Updates the provided summary using the data in update")
+  ;
+
+  using py_tuple = tuple_sketch<py::object>;
+  using py_update_tuple = update_tuple_sketch<py::object, py::object, tuple_policy_holder>;
+  using py_compact_tuple = compact_tuple_sketch<py::object>;
+
+  py::class_<py_tuple>(m, "tuple_sketch")
+    .def("__str__", &py_tuple::to_string, py::arg("print_items")=false,
+         "Produces a string summary of the sketch")
+    .def("to_string", &py_tuple::to_string, py::arg("print_items")=false,
+         "Produces a string summary of the sketch")
+    .def("is_empty", &py_tuple::is_empty,
+         "Returns True if the sketch is empty, otherwise False")
+    .def("get_estimate", &py_tuple::get_estimate,
+         "Estimate of the distinct count of the input stream")
+    .def("get_upper_bound", static_cast<double (py_tuple::*)(uint8_t) const>(&py_tuple::get_upper_bound), py::arg("num_std_devs"),
+         "Returns an approximate upper bound on the estimate at standard deviations in {1, 2, 3}")
+    .def("get_lower_bound", static_cast<double (py_tuple::*)(uint8_t) const>(&py_tuple::get_lower_bound), py::arg("num_std_devs"),
+         "Returns an approximate lower bound on the estimate at standard deviations in {1, 2, 3}")
+    .def("is_estimation_mode", &py_tuple::is_estimation_mode,
+         "Returns True if sketch is in estimation mode, otherwise False")
+    .def("get_theta", &py_tuple::get_theta,
+         "Returns theta (effective sampling rate) as a fraction from 0 to 1")
+    .def("get_theta64", &py_tuple::get_theta64,
+         "Returns theta as 64-bit value")
+    .def("get_num_retained", &py_tuple::get_num_retained,
+         "Retunrs the number of items currently in the sketch")
+    .def("get_seed_hash", [](const py_tuple& sk) { return sk.get_seed_hash(); }, // why does regular call not work??
+         "Returns a hash of the seed used in the sketch")
+    .def("is_ordered", &py_tuple::is_ordered,
+         "Returns True if the sketch entries are sorted, otherwise False")
+    .def("__iter__", [](const py_tuple& s) { return py::make_iterator(s.begin(), s.end()); })
+  ;
+
+  py::class_<py_compact_tuple, py_tuple>(m, "compact_tuple_sketch")
+    .def(py::init<const py_compact_tuple&>())
+    .def(py::init<const py_tuple&, bool>())
+    .def(
+        "serialize",
+        [](const py_compact_tuple& sk, py_object_serde& serde) {
+          auto bytes = sk.serialize(0, serde);
+          return py::bytes(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+        }, py::arg("serde"),
+        "Serializes the sketch into a bytes object"
+    )
+    .def_static(
+        "deserialize",
+        [](const std::string& bytes, uint64_t seed, py_object_serde& serde) {
+          return py_compact_tuple::deserialize(bytes.data(), bytes.size(), seed, serde);
+        },
+        py::arg("bytes"), py::arg("seed")=DEFAULT_SEED, py::arg("serde"),
+        "Reads a bytes object and returns the corresponding compact_tuple_sketch"
+    );
+
+  py::class_<py_update_tuple, py_tuple>(m, "update_tuple_sketch")
+    .def(
+        py::init([](uint8_t lg_k, std::shared_ptr<tuple_policy> policy, double p, uint64_t seed) {
+          tuple_policy_holder holder(policy);
+          return py_update_tuple::builder(holder).set_lg_k(lg_k).set_p(p).set_seed(seed).build();
+        }),
+        py::arg("lg_k")=theta_constants::DEFAULT_LG_K, py::arg("policy"), py::arg("p")=1.0, py::arg("seed")=DEFAULT_SEED
+    )
+    .def(py::init<const py_update_tuple&>())
+    .def("update", (void (py_update_tuple::*)(int64_t, py::object&)) &py_update_tuple::update,
+         py::arg("datum"), py::arg("summary"),
+         "Updates the sketch with the given integral value")
+    .def("update", (void (py_update_tuple::*)(double, py::object&)) &py_update_tuple::update,
+         py::arg("datum"), py::arg("summary"),
+         "Updates the sketch with the given floating point value")
+    .def("update", (void (py_update_tuple::*)(const std::string&, py::object&)) &py_update_tuple::update,
+         py::arg("datum"), py::arg("summary"),
+         "Updates the sketch with the given string")
+    .def("compact", &py_update_tuple::compact, py::arg("ordered")=true,
+         "Returns a compacted form of the sketch, optionally sorting it")
+  ;
+
+/*
+  py::class_<theta_union>(m, "theta_union")
+    .def(
+        py::init([](uint8_t lg_k, double p, uint64_t seed) {
+          return theta_union::builder().set_lg_k(lg_k).set_p(p).set_seed(seed).build();
+        }),
+        py::arg("lg_k")=theta_constants::DEFAULT_LG_K, py::arg("p")=1.0, py::arg("seed")=DEFAULT_SEED
+    )
+    .def("update", &theta_union::update<const theta_sketch&>, py::arg("sketch"),
+         "Updates the union with the given sketch")
+    .def("get_result", &theta_union::get_result, py::arg("ordered")=true,
+         "Returns the sketch corresponding to the union result")
+  ;
+
+  py::class_<theta_intersection>(m, "theta_intersection")
+    .def(py::init<uint64_t>(), py::arg("seed")=DEFAULT_SEED)
+    .def(py::init<const theta_intersection&>())
+    .def("update", &theta_intersection::update<const theta_sketch&>, py::arg("sketch"),
+         "Intersections the provided sketch with the current intersection state")
+    .def("get_result", &theta_intersection::get_result, py::arg("ordered")=true,
+         "Returns the sketch corresponding to the intersection result")
+    .def("has_result", &theta_intersection::has_result,
+         "Returns True if the intersection has a valid result, otherwise False")
+  ;
+
+  py::class_<theta_a_not_b>(m, "theta_a_not_b")
+    .def(py::init<uint64_t>(), py::arg("seed")=DEFAULT_SEED)
+    .def(
+        "compute",
+        &theta_a_not_b::compute<const theta_sketch&, const theta_sketch&>,
+        py::arg("a"), py::arg("b"), py::arg("ordered")=true,
+        "Returns a sketch with the reuslt of appying the A-not-B operation on the given inputs"
+    )
+  ;
+  
+  py::class_<theta_jaccard_similarity>(m, "theta_jaccard_similarity")
+    .def_static(
+        "jaccard",
+        [](const theta_sketch& sketch_a, const theta_sketch& sketch_b, uint64_t seed) {
+          return theta_jaccard_similarity::jaccard(sketch_a, sketch_b, seed);
+        },
+        py::arg("sketch_a"), py::arg("sketch_b"), py::arg("seed")=DEFAULT_SEED,
+        "Returns a list with {lower_bound, estimate, upper_bound} of the Jaccard similarity between sketches"
+    )
+    .def_static(
+        "exactly_equal",
+        &theta_jaccard_similarity::exactly_equal<const theta_sketch&, const theta_sketch&>,
+        py::arg("sketch_a"), py::arg("sketch_b"), py::arg("seed")=DEFAULT_SEED,
+        "Returns True if sketch_a and sketch_b are equivalent, otherwise False"
+    )
+    .def_static(
+        "similarity_test",
+        &theta_jaccard_similarity::similarity_test<const theta_sketch&, const theta_sketch&>,
+        py::arg("actual"), py::arg("expected"), py::arg("threshold"), py::arg("seed")=DEFAULT_SEED,
+        "Tests similarity of an actual sketch against an expected sketch. Computers the lower bound of the Jaccard "
+        "index J_{LB} of the actual and expected sketches. If J_{LB} >= threshold, then the sketches are considered "
+        "to be similar sith a confidence of 97.7% and returns True, otherwise False.")
+    .def_static(
+        "dissimilarity_test",
+        &theta_jaccard_similarity::dissimilarity_test<const theta_sketch&, const theta_sketch&>,
+        py::arg("actual"), py::arg("expected"), py::arg("threshold"), py::arg("seed")=DEFAULT_SEED,
+        "Tests dissimilarity of an actual sketch against an expected sketch. Computers the lower bound of the Jaccard "
+        "index J_{UB} of the actual and expected sketches. If J_{UB} <= threshold, then the sketches are considered "
+        "to be dissimilar sith a confidence of 97.7% and returns True, otherwise False."
+    )
+  ;
+  */
+}

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
     url='http://datasketches.apache.org',
     long_description=open('python/README.md').read(),
     long_description_content_type='text/markdown',
-    packages=find_packages(where='python',exclude=['src','*tests*']), # src not needed if only the .so
+    packages=find_packages(where='python',exclude=['src','include','*tests*']), # src not needed if only the .so
     package_dir={'':'python'},
     # may need to add all source paths for sdist packages w/o MANIFEST.in
     ext_modules=[CMakeExtension('datasketches')],


### PR DESCRIPTION
This adds tuple sketch support to the python library, and specifically provides an arbitrary python object as the summary, as well as custom python policies for set operations.

A few basic policy implementations are included. They both demonstrate examples of how to implement a custom policy as well as provide a few basic options that seem reasonably useful. (The always 1 policy perhaps less so.)

I think I should probably split the code in tuple_wrapper.cpp into a couple files, specifically pulling out the policy structs into their own header. But that would only ever be used from that one wrapper class so it's not obvious if that's actually useful?