### PR TITLE
Python tuple sketch

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(python
     cpc
     fi
     theta
+    tuple
     sampling
     req
     quantiles
@@ -72,6 +73,7 @@ target_sources(python
     src/cpc_wrapper.cpp
     src/fi_wrapper.cpp
     src/theta_wrapper.cpp
+    src/tuple_wrapper.cpp
     src/vo_wrapper.cpp
     src/req_wrapper.cpp
     src/quantiles_wrapper.cpp

--- a/python/datasketches/PySerDe.py
+++ b/python/datasketches/PySerDe.py
@@ -54,51 +54,57 @@ class PyStringsSerDe(PyObjectSerDe):
     str = data[offset+4:offset+4+num_chars].decode()
     return (str, 4+num_chars)
 
-# Implements an integer-encoding scheme where each integer is written
+# Implements an integer encoding scheme where each integer is written
 # as a 32-bit (4 byte) little-endian value.
 class PyIntsSerDe(PyObjectSerDe):
   def get_size(self, item):
     return int(4)
 
   def to_bytes(self, item):
-    return struct.pack('i', item)
+    return struct.pack('<i', item)
 
   def from_bytes(self, data: bytes, offset: int):
-    val = struct.unpack_from('i', data, offset)[0]
+    val = struct.unpack_from('<i', data, offset)[0]
     return (val, 4)
 
 
+# Implements an integer encoding scheme where each integer is written
+# as a 64-bit (8 byte) little-endian value.
 class PyLongsSerDe(PyObjectSerDe):
   def get_size(self, item):
     return int(8)
 
   def to_bytes(self, item):
-    return struct.pack('l', item)
+    return struct.pack('<l', item)
 
   def from_bytes(self, data: bytes, offset: int):
-    val = struct.unpack_from('l', data, offset)[0]
+    val = struct.unpack_from('<l', data, offset)[0]
     return (val, 8)
 
 
+# Implements a floating point encoding scheme where each value is written
+# as a 32-bit floating point value.
 class PyFloatsSerDe(PyObjectSerDe):
   def get_size(self, item):
     return int(4)
 
   def to_bytes(self, item):
-    return struct.pack('f', item)
+    return struct.pack('<f', item)
 
   def from_bytes(self, data: bytes, offset: int):
-    val = struct.unpack_from('f', data, offset)[0]
+    val = struct.unpack_from('<f', data, offset)[0]
     return (val, 4)
 
 
+# Implements a floating point encoding scheme where each value is written
+# as a 64-bit floating point value.
 class PyDoublesSerDe(PyObjectSerDe):
   def get_size(self, item):
     return int(8)
 
   def to_bytes(self, item):
-    return struct.pack('d', item)
+    return struct.pack('<d', item)
 
   def from_bytes(self, data: bytes, offset: int):
-    val = struct.unpack_from('d', data, offset)[0]
+    val = struct.unpack_from('<d', data, offset)[0]
     return (val, 8)

--- a/python/datasketches/TuplePolicy.py
+++ b/python/datasketches/TuplePolicy.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import sys
+
 from _datasketches import TuplePolicy
 
 # This file provides an example Python Tuple Policy implementation.
@@ -25,7 +27,7 @@ from _datasketches import TuplePolicy
 #   * update_summary(summary, update) applies the relevant policy to update the
 #     provided summary with the data in update.
 #   * __call__ may be similar to update_summary but allows a different
-#     implementation for set operations
+#     implementation for set operations (union and intersection)
 
 # Implements an accumulator summary policy, where new values are
 # added to the existing value.
@@ -43,3 +45,48 @@ class AccumulatorPolicy(TuplePolicy):
   def __call__(self, summary: int, update: int) -> int:
     summary += update
     return summary
+
+
+# Implements a MAX rule, where the largest integer value is always kept
+class MaxIntPolicy(TuplePolicy):
+  def __init__(self):
+    TuplePolicy.__init__(self)
+
+  def create_summary(self) -> int:
+    return int(-sys.maxsize-1)
+
+  def update_summary(self, summary: int, update: int) -> int:
+    return max(summary, update)
+
+  def __call__(self, summary: int, update: int) -> int:
+    return max(summary, update)
+
+
+# Implements a MIN rule, where the smallest integer value is always kept
+class MinIntPolicy(TuplePolicy):
+  def __init__(self):
+    TuplePolicy.__init__(self)
+
+  def create_summary(self) -> int:
+    return int(sys.maxsize)
+
+  def update_summary(self, summary: int, update: int) -> int:
+    return min(summary, update)
+
+  def __call__(self, summary: int, update: int) -> int:
+    return min(summary, update)
+
+
+# Implements an Always One policy, where the summary is always exactly 1
+class AkwaysOnePolicy(TuplePolicy):
+  def __init__(self):
+    TuplePolicy.__init__(self)
+
+  def create_summary(self) -> int:
+    return int(1)
+
+  def update_summary(self, summary: int, update: int) -> int:
+    return int(1)
+
+  def __call__(self, summary: int, update: int) -> int:
+    return int(1)

--- a/python/datasketches/TuplePolicy.py
+++ b/python/datasketches/TuplePolicy.py
@@ -21,19 +21,25 @@ from _datasketches import TuplePolicy
 #
 # Each implementation must extend the PyTuplePolicy class and define
 # two methods:
-#   * create() returns a new Summary object
-#   * update(summary, update) applies the relevant policy to update the
+#   * create_summary() returns a new Summary object
+#   * update_summary(summary, update) applies the relevant policy to update the
 #     provided summary with the data in update.
+#   * __call__ may be similar to update_summary but allows a different
+#     implementation for set operations
 
 # Implements an accumulator summary policy, where new values are
 # added to the existing value.
-class AccumulatorUpdatePolicy(TuplePolicy):
+class AccumulatorPolicy(TuplePolicy):
   def __init__(self):
     TuplePolicy.__init__(self)
 
-  def create_summary(self):
+  def create_summary(self) -> int:
     return int(0)
 
-  def update_summary(self, summary: int, update: int):
+  def update_summary(self, summary: int, update: int) -> int:
+    summary += update
+    return summary
+
+  def __call__(self, summary: int, update: int) -> int:
     summary += update
     return summary

--- a/python/datasketches/TuplePolicy.py
+++ b/python/datasketches/TuplePolicy.py
@@ -75,18 +75,3 @@ class MinIntPolicy(TuplePolicy):
 
   def __call__(self, summary: int, update: int) -> int:
     return min(summary, update)
-
-
-# Implements an Always One policy, where the summary is always exactly 1
-class AkwaysOnePolicy(TuplePolicy):
-  def __init__(self):
-    TuplePolicy.__init__(self)
-
-  def create_summary(self) -> int:
-    return int(1)
-
-  def update_summary(self, summary: int, update: int) -> int:
-    return int(1)
-
-  def __call__(self, summary: int, update: int) -> int:
-    return int(1)

--- a/python/datasketches/TuplePolicy.py
+++ b/python/datasketches/TuplePolicy.py
@@ -15,9 +15,25 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name = 'datasketches'
+from _datasketches import TuplePolicy
 
-from .PySerDe import *
-from .TuplePolicy import *
+# This file provides an example Python Tuple Policy implementation.
+#
+# Each implementation must extend the PyTuplePolicy class and define
+# two methods:
+#   * create() returns a new Summary object
+#   * update(summary, update) applies the relevant policy to update the
+#     provided summary with the data in update.
 
-from _datasketches import *
+# Implements an accumulator summary policy, where new values are
+# added to the existing value.
+class AccumulatorUpdatePolicy(TuplePolicy):
+  def __init__(self):
+    TuplePolicy.__init__(self)
+
+  def create_summary(self):
+    return int(0)
+
+  def update_summary(self, summary: int, update: int):
+    summary += update
+    return summary

--- a/python/datasketches/TupleWrapper.py
+++ b/python/datasketches/TupleWrapper.py
@@ -15,14 +15,80 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from abc import ABC, abstractmethod
+
 from .TuplePolicy import TuplePolicy
-from _datasketches import _update_tuple_sketch, _tuple_union, _tuple_intersection
-from _datasketches import _tuple_a_not_b#, _tuple_jaccard_similarity
-from _datasketches import tuple_sketch, compact_tuple_sketch
+from _datasketches import _tuple_sketch, _compact_tuple_sketch, _update_tuple_sketch
+from _datasketches import  _tuple_union, _tuple_intersection
+from _datasketches import _tuple_a_not_b, _tuple_jaccard_similarity
+from _datasketches import PyObjectSerDe
+
+class tuple_sketch(ABC):
+  _gadget: _tuple_sketch
+
+  def __str__(self, print_items:bool=False):
+    return self._gadget.to_string(print_items)
+
+  def is_empty(self):
+    return self._gadget.is_empty()
+
+  def get_estimate(self):
+    return self._gadget.get_estimate()
+
+  def get_upper_bound(self, num_std_devs:int):
+    return self._gadget.get_upper_bound(num_std_devs)
+
+  def get_lower_bound(self, num_std_devs:int):
+    return self._gadget.get_lower_bound(num_std_devs)
+
+  def is_estimation_mode(self):
+    return self._gadget.is_estimation_mode()
+
+  def get_theta(self):
+    return self._gadget.get_theta()
+
+  def get_theta64(self):
+    return self._gadget.get_theta64()
+
+  def get_num_retained(self):
+    return self._gadget.get_num_retained()
+
+  def get_seed_hash(self):
+    return self._gadget.get_seed_hash()
+
+  def is_ordered(self):
+    return self._gadget.is_ordered()
+
+  def __iter__(self):
+    return self._gadget.__iter__()
+
+  #.def("__iter__", [](const py_tuple_sketch& s) { return py::make_iterator(s.begin(), s.end()); })
+
+
+class compact_tuple_sketch(tuple_sketch):
+  def __init__(self, other:tuple_sketch, ordered:bool = True):
+    if other == None:
+      self._gadget = None
+    else:
+      self._gadget = _compact_tuple_sketch(other, ordered)
+
+  def serialize(self, serde:PyObjectSerDe):
+    return self._gadget.serialize(serde)
+
+  # TODO: define seed from constant
+  @staticmethod
+  def deserialize(data:bytes, serde:PyObjectSerDe, seed:int=9001):
+    cpp_sk = _compact_tuple_sketch.deserialize(data, serde, seed)
+    # TODO: this seems inefficinet -- is there some sort of _wrap()
+    # approach that might work better?
+    sk = compact_tuple_sketch(None, True)
+    sk._gadget = cpp_sk
+    return sk
+
 
 class update_tuple_sketch(tuple_sketch):
+  # TODO: define seed from constant
   def __init__(self, policy, lg_k:int = 12, p:float = 1.0, seed:int = 9001):
-    #tuple_sketch.__init__(self) # abstract so a no-op
     self._policy = policy
     self._gadget = _update_tuple_sketch(self._policy, lg_k, p, seed)
 
@@ -40,16 +106,15 @@ class tuple_union:
     self._gadget = _tuple_union(self._policy, lg_k, p, seed)
 
   def update(self, sketch:tuple_sketch):
-    if isinstance(sketch, compact_tuple_sketch):
-      self._gadget.update(sketch)
-    else:
       self._gadget.update(sketch._gadget)
 
   def get_result(self, ordered:bool = True) -> compact_tuple_sketch:
-    return self._gadget.get_result()
+    sk = compact_tuple_sketch(self._gadget.get_result(ordered), ordered)
+    return sk
 
   def reset(self):
     self._gadget.reset()
+
 
 class tuple_intersection:
   # TODO: define seed from constant
@@ -58,20 +123,39 @@ class tuple_intersection:
     self._gadget = _tuple_intersection(self._policy, seed)
 
   def update(self, sketch:tuple_sketch):
-    if isinstance(sketch, compact_tuple_sketch):
-      self._gadget.update(sketch)
-    else:
-      self._gadget.update(sketch._gadget)
+    self._gadget.update(sketch._gadget)
 
   def has_result(self) -> bool:
     return self._gadget.has_result()
 
   def get_result(self, ordered:bool = True) -> compact_tuple_sketch:
-    return self._gadget.get_result(ordered)
+    sk = compact_tuple_sketch(self._gadget.get_result(ordered), ordered)
+    return sk
+
 
 class tuple_a_not_b:
   def __init__(self, seed:int = 9001):
     self._gadget = _tuple_a_not_b(seed)
   
   def compute(self, a:tuple_sketch, b:tuple_sketch, ordered:bool=True) -> compact_tuple_sketch:
-    return self._gadget.compute(a, b)
+    sk = compact_tuple_sketch(self._gadget.compute(a._gadget, b._gadget))
+    return sk
+
+
+class tuple_jaccard_similarity:
+  # TODO: define seed from constant
+  @staticmethod  
+  def jaccard(a:tuple_sketch, b:tuple_sketch, seed:int=9001):
+    return _tuple_jaccard_similarity.jaccard(a._gadget, b._gadget, seed)
+
+  @staticmethod
+  def exactly_equal(a:tuple_sketch, b:tuple_sketch, seed:int=9001):
+    return _tuple_jaccard_similarity.exactly_equal(a._gadget, b._gadget, seed)
+
+  @staticmethod
+  def similarity_test(actual:tuple_sketch, expected:tuple_sketch, threshold:float, seed:int=9001):
+    return _tuple_jaccard_similarity.similarity_test(actual._gadget, expected._gadget, threshold, seed)
+
+  @staticmethod
+  def dissimilarity_test(actual:tuple_sketch, expected:tuple_sketch, threshold:float, seed:int=9001):
+    return _tuple_jaccard_similarity.dissimilarity_test(actual._gadget, expected._gadget, threshold, seed)

--- a/python/datasketches/TupleWrapper.py
+++ b/python/datasketches/TupleWrapper.py
@@ -21,51 +21,62 @@ from .TuplePolicy import TuplePolicy
 from _datasketches import _tuple_sketch, _compact_tuple_sketch, _update_tuple_sketch
 from _datasketches import  _tuple_union, _tuple_intersection
 from _datasketches import _tuple_a_not_b, _tuple_jaccard_similarity
-from _datasketches import PyObjectSerDe
+from _datasketches import PyObjectSerDe, theta_sketch
 
 class tuple_sketch(ABC):
+  """An abstract base class representing a Tuple Sketch."""
   _gadget: _tuple_sketch
 
   def __str__(self, print_items:bool=False):
     return self._gadget.to_string(print_items)
 
   def is_empty(self):
+    """Returns True if the sketch is empty, otherwise False."""
     return self._gadget.is_empty()
 
   def get_estimate(self):
+    """Returns an estimate of the distinct count of the input stream."""
     return self._gadget.get_estimate()
 
   def get_upper_bound(self, num_std_devs:int):
+    """Returns an approximate upper bound on the estimate at standard deviations in {1, 2, 3}."""
     return self._gadget.get_upper_bound(num_std_devs)
 
   def get_lower_bound(self, num_std_devs:int):
+    """Returns an approximate lower bound on the estimate at standard deviations in {1, 2, 3}."""
     return self._gadget.get_lower_bound(num_std_devs)
 
   def is_estimation_mode(self):
+    """Returns True if the sketch is in estimation mode, otherwise False."""
     return self._gadget.is_estimation_mode()
 
   def get_theta(self):
+    """Returns theta (the effective sampling rate) as a fraction from 0 to 1."""
     return self._gadget.get_theta()
 
   def get_theta64(self):
+    """Returns theta as a 64-bit integer value."""
     return self._gadget.get_theta64()
 
   def get_num_retained(self):
+    """Returns the number of items currently in the sketch."""
     return self._gadget.get_num_retained()
 
   def get_seed_hash(self):
+    """Returns a hash of the seed used in the sketch."""
     return self._gadget.get_seed_hash()
 
   def is_ordered(self):
+    """Returns True if the sketch entries are sorder, otherwise False."""
     return self._gadget.is_ordered()
 
   def __iter__(self):
     return self._gadget.__iter__()
 
-  #.def("__iter__", [](const py_tuple_sketch& s) { return py::make_iterator(s.begin(), s.end()); })
-
 
 class compact_tuple_sketch(tuple_sketch):
+  """An instance of a Tuple Sketch that has been compacted and can no longer accept updates."""
+
   def __init__(self, other:tuple_sketch, ordered:bool = True):
     if other == None:
       self._gadget = None
@@ -73,89 +84,123 @@ class compact_tuple_sketch(tuple_sketch):
       self._gadget = _compact_tuple_sketch(other, ordered)
 
   def serialize(self, serde:PyObjectSerDe):
+    """Serializes the sketch into a bytes object with the provided SerDe."""
     return self._gadget.serialize(serde)
 
-  # TODO: define seed from constant
-  @staticmethod
-  def deserialize(data:bytes, serde:PyObjectSerDe, seed:int=9001):
-    cpp_sk = _compact_tuple_sketch.deserialize(data, serde, seed)
-    # TODO: this seems inefficinet -- is there some sort of _wrap()
-    # approach that might work better?
-    sk = compact_tuple_sketch(None, True)
-    sk._gadget = cpp_sk
-    return sk
+  @classmethod
+  def from_theta_sketch(cls, sketch:theta_sketch, summary, seed:int=_tuple_sketch.DEFAULT_SEED):
+    """Creates a comapct Tuple Sketch from a Theta Sketch using a fixed summary value."""
+    self = cls.__new__(cls)
+    self._gadget = _compact_tuple_sketch(sketch, summary, seed)
+    return self
+
+  @classmethod
+  def deserialize(cls, data:bytes, serde:PyObjectSerDe, seed:int=_tuple_sketch.DEFAULT_SEED):
+    """Reads a bytes object and uses the provded SerDe to return the corresponding compact_tuple_sketch."""
+    self = cls.__new__(cls)
+    self._gadget = _compact_tuple_sketch.deserialize(data, serde, seed)
+    return self
 
 
 class update_tuple_sketch(tuple_sketch):
-  # TODO: define seed from constant
-  def __init__(self, policy, lg_k:int = 12, p:float = 1.0, seed:int = 9001):
+  """An instance of a Tuple Sketch that is available for updates. Requires a Policy object to handle Summary values."""
+
+  def __init__(self, policy, lg_k:int = 12, p:float = 1.0, seed:int = _tuple_sketch.DEFAULT_SEED):
     self._policy = policy
     self._gadget = _update_tuple_sketch(self._policy, lg_k, p, seed)
 
-  # TODO: do we need multiple update formats?
-  def update(self, datum, summary):
-    self._gadget.update(datum, summary)
+  def update(self, datum, value):
+    """Updates the sketch with the provided item and summary value."""
+    self._gadget.update(datum, value)
 
   def compact(self, ordered:bool = True) -> compact_tuple_sketch:
+    """Returns a compacted form of the sketch, optionally sorting it."""
     return self._gadget.compact(ordered)
 
+  def reset(self):
+    """Resets the sketch to the initial empty state."""
+    self._gadget.reset()
+
+
 class tuple_union:
-  # TODO: define seed from constant
-  def __init__(self, policy:TuplePolicy, lg_k:int = 12, p:float = 1.0, seed:int = 9001):
+  """An object that can merge Tuple Sketches. Requires a Policy object to handle merging Summaries."""
+  _policy: TuplePolicy
+
+  def __init__(self, policy:TuplePolicy, lg_k:int = 12, p:float = 1.0, seed:int = _tuple_sketch.DEFAULT_SEED):
     self._policy = policy
     self._gadget = _tuple_union(self._policy, lg_k, p, seed)
 
   def update(self, sketch:tuple_sketch):
-      self._gadget.update(sketch._gadget)
+    """Updates the union with the given sketch."""
+    self._gadget.update(sketch._gadget)
 
   def get_result(self, ordered:bool = True) -> compact_tuple_sketch:
-    sk = compact_tuple_sketch(self._gadget.get_result(ordered), ordered)
-    return sk
+    """Returns the sketch corresponding to the union result, optionally sorted."""
+    return compact_tuple_sketch(self._gadget.get_result(ordered), ordered)
 
   def reset(self):
+    """Resets the union to the initial empty state."""
     self._gadget.reset()
 
 
 class tuple_intersection:
-  # TODO: define seed from constant
-  def __init__(self, policy:TuplePolicy, seed:int = 9001):
+  """An object that can intersect Tuple Sketches. Requires a Policy object to handle intersecting Summaries."""
+  _policy: TuplePolicy
+
+  def __init__(self, policy:TuplePolicy, seed:int = _tuple_sketch.DEFAULT_SEED):
     self._policy = policy
     self._gadget = _tuple_intersection(self._policy, seed)
 
   def update(self, sketch:tuple_sketch):
+    """Intersects the provided sketch with the current intersection state."""
     self._gadget.update(sketch._gadget)
 
   def has_result(self) -> bool:
+    """Returns True if the intersection has a valid result, otherwise False."""
     return self._gadget.has_result()
 
   def get_result(self, ordered:bool = True) -> compact_tuple_sketch:
-    sk = compact_tuple_sketch(self._gadget.get_result(ordered), ordered)
-    return sk
+    """Returns the sketch corresponding to the intersection result, optionally sorted."""
+    return compact_tuple_sketch(self._gadget.get_result(ordered), ordered)
 
 
 class tuple_a_not_b:
-  def __init__(self, seed:int = 9001):
+  """An object that can peform the A-not-B operation between two sketches."""
+  def __init__(self, seed:int = _tuple_sketch.DEFAULT_SEED):
     self._gadget = _tuple_a_not_b(seed)
   
   def compute(self, a:tuple_sketch, b:tuple_sketch, ordered:bool=True) -> compact_tuple_sketch:
-    sk = compact_tuple_sketch(self._gadget.compute(a._gadget, b._gadget))
-    return sk
+    """Returns a sketch with the result of applying the A-not-B operation on the given inputs."""
+    return compact_tuple_sketch(self._gadget.compute(a._gadget, b._gadget))
 
 
 class tuple_jaccard_similarity:
-  # TODO: define seed from constant
   @staticmethod  
-  def jaccard(a:tuple_sketch, b:tuple_sketch, seed:int=9001):
+  def jaccard(a:tuple_sketch, b:tuple_sketch, seed:int=_tuple_sketch.DEFAULT_SEED):
+    """Returns a list with {lower_bound, estimate, upper_bound} of the Jaccard similarity between sketches."""
     return _tuple_jaccard_similarity.jaccard(a._gadget, b._gadget, seed)
 
   @staticmethod
-  def exactly_equal(a:tuple_sketch, b:tuple_sketch, seed:int=9001):
+  def exactly_equal(a:tuple_sketch, b:tuple_sketch, seed:int=_tuple_sketch.DEFAULT_SEED):
+    """Returns True if sketch_a and sketch_b are equivalent, otherwise False."""
     return _tuple_jaccard_similarity.exactly_equal(a._gadget, b._gadget, seed)
 
   @staticmethod
-  def similarity_test(actual:tuple_sketch, expected:tuple_sketch, threshold:float, seed:int=9001):
+  def similarity_test(actual:tuple_sketch, expected:tuple_sketch, threshold:float, seed:int=_tuple_sketch.DEFAULT_SEED):
+    """Tests similarity of an actual sketch against an expected sketch.
+
+    Computes the lower bound of the Jaccard index J_{LB} of the actual and expected sketches.
+    If J_{LB} >= threshold, then the sketches are considered to be similar sith a confidence of
+    97.7% and returns True, otherwise False.
+    """
     return _tuple_jaccard_similarity.similarity_test(actual._gadget, expected._gadget, threshold, seed)
 
   @staticmethod
-  def dissimilarity_test(actual:tuple_sketch, expected:tuple_sketch, threshold:float, seed:int=9001):
+  def dissimilarity_test(actual:tuple_sketch, expected:tuple_sketch, threshold:float, seed:int=_tuple_sketch.DEFAULT_SEED):
+    """Tests dissimilarity of an actual sketch against an expected sketch.
+
+    Computes the upper bound of the Jaccard index J_{UB} of the actual and expected sketches.
+    If J_{UB} <= threshold, then the sketches are considered to be dissimilar sith a confidence of
+    97.7% and returns True, otherwise False.
+    """
     return _tuple_jaccard_similarity.dissimilarity_test(actual._gadget, expected._gadget, threshold, seed)

--- a/python/datasketches/TupleWrapper.py
+++ b/python/datasketches/TupleWrapper.py
@@ -1,0 +1,77 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from .TuplePolicy import TuplePolicy
+from _datasketches import _update_tuple_sketch, _tuple_union, _tuple_intersection
+from _datasketches import _tuple_a_not_b#, _tuple_jaccard_similarity
+from _datasketches import tuple_sketch, compact_tuple_sketch
+
+class update_tuple_sketch(tuple_sketch):
+  def __init__(self, policy, lg_k:int = 12, p:float = 1.0, seed:int = 9001):
+    #tuple_sketch.__init__(self) # abstract so a no-op
+    self._policy = policy
+    self._gadget = _update_tuple_sketch(self._policy, lg_k, p, seed)
+
+  # TODO: do we need multiple update formats?
+  def update(self, datum, summary):
+    self._gadget.update(datum, summary)
+
+  def compact(self, ordered:bool = True) -> compact_tuple_sketch:
+    return self._gadget.compact(ordered)
+
+class tuple_union:
+  # TODO: define seed from constant
+  def __init__(self, policy:TuplePolicy, lg_k:int = 12, p:float = 1.0, seed:int = 9001):
+    self._policy = policy
+    self._gadget = _tuple_union(self._policy, lg_k, p, seed)
+
+  def update(self, sketch:tuple_sketch):
+    if isinstance(sketch, compact_tuple_sketch):
+      self._gadget.update(sketch)
+    else:
+      self._gadget.update(sketch._gadget)
+
+  def get_result(self, ordered:bool = True) -> compact_tuple_sketch:
+    return self._gadget.get_result()
+
+  def reset(self):
+    self._gadget.reset()
+
+class tuple_intersection:
+  # TODO: define seed from constant
+  def __init__(self, policy:TuplePolicy, seed:int = 9001):
+    self._policy = policy
+    self._gadget = _tuple_intersection(self._policy, seed)
+
+  def update(self, sketch:tuple_sketch):
+    if isinstance(sketch, compact_tuple_sketch):
+      self._gadget.update(sketch)
+    else:
+      self._gadget.update(sketch._gadget)
+
+  def has_result(self) -> bool:
+    return self._gadget.has_result()
+
+  def get_result(self, ordered:bool = True) -> compact_tuple_sketch:
+    return self._gadget.get_result(ordered)
+
+class tuple_a_not_b:
+  def __init__(self, seed:int = 9001):
+    self._gadget = _tuple_a_not_b(seed)
+  
+  def compute(self, a:tuple_sketch, b:tuple_sketch, ordered:bool=True) -> compact_tuple_sketch:
+    return self._gadget.compute(a, b)

--- a/python/datasketches/__init__.py
+++ b/python/datasketches/__init__.py
@@ -15,6 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""The Apache DataSketches Library for Python
+
+Provided under the Apache License, Verison 2.0
+<http://www.apache.org/licenses/LICENSE-2.0>
+"""
+
 name = 'datasketches'
 
 from _datasketches import *
@@ -27,8 +33,4 @@ from .TuplePolicy import *
 # the C++ object. Currently, the native python portion of
 # a class derived from a C++ class may be garbage collected
 # even though a pointer to the C++ portion remains valid.
-#
-# These wrappers should exactly implement the target API
-# for the pybind11 interface so they can be removed if
-# that issue is ever fixed.
 from .TupleWrapper import *

--- a/python/datasketches/__init__.py
+++ b/python/datasketches/__init__.py
@@ -17,7 +17,18 @@
 
 name = 'datasketches'
 
+from _datasketches import *
+
 from .PySerDe import *
 from .TuplePolicy import *
 
-from _datasketches import *
+# Wrappers around the pybind11 classes for cases where we
+# need to define a python object that is persisted within
+# the C++ object. Currently, the native python portion of
+# a class derived from a C++ class may be garbage collected
+# even though a pointer to the C++ portion remains valid.
+#
+# These wrappers should exactly implement the target API
+# for the pybind11 interface so they can be removed if
+# that issue is ever fixed.
+from .TupleWrapper import *

--- a/python/include/tuple_policy.hpp
+++ b/python/include/tuple_policy.hpp
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <memory>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "theta_sketch.hpp"
+#include "tuple_sketch.hpp"
+#include "tuple_union.hpp"
+#include "tuple_intersection.hpp"
+#include "tuple_a_not_b.hpp"
+#include "theta_jaccard_similarity_base.hpp"
+#include "common_defs.hpp"
+
+#include "py_serde.hpp"
+
+#ifndef _TUPLE_POLICY_HPP_
+#define _TUPLE_POLICY_HPP_
+
+namespace py = pybind11;
+
+namespace datasketches {
+
+/**
+ * @brief tuple_policy provides the underlying base class from
+ *        which native Python policies ultimately inherit. The actual
+ *        policies implement TuplePolicy, as shown in TuplePolicy.py
+ */
+struct tuple_policy {
+  virtual py::object create_summary() const = 0;
+  virtual py::object update_summary(py::object& summary, const py::object& update) const = 0;
+  virtual py::object operator()(py::object& summary, const py::object& update) const = 0;
+  virtual ~tuple_policy() = default;
+};
+
+/**
+ * @brief TuplePolicy provides the "trampoline" class for pybind11
+ *        that allows for a native Python implementation of tuple
+ *        sketch policies.
+ */
+struct TuplePolicy : public tuple_policy {
+  using tuple_policy::tuple_policy;
+
+  /**
+   * @brief Create a summary object
+   * 
+   * @return py::object representing a new summary
+   */
+  py::object create_summary() const override {
+    PYBIND11_OVERRIDE_PURE(
+      py::object,          // Return type
+      tuple_policy,        // Parent class
+      create_summary,      // Name of function in C++ (must match Python name)
+                           // Argument(s) -- if any
+    );
+  }
+
+  /**
+   * @brief Update a summary object using this policy
+   * 
+   * @param summary The current summary to update
+   * @param update The new value with which to update the summary
+   * @return py::object The updated summary
+   */
+  py::object update_summary(py::object& summary, const py::object& update) const override {
+    PYBIND11_OVERRIDE_PURE(
+      py::object,          // Return type
+      tuple_policy,        // Parent class
+      update_summary,      // Name of function in C++ (must match Python name)
+      summary, update      // Arguments
+    );
+  }
+
+  /**
+   * @brief Applies this policy to summary with the provided update
+   * 
+   * @param summary The current summary on which to apply the policy
+   * @param update An update to apply to the current summary
+   * @return py::object The potentially modified summary
+   */
+  py::object operator()(py::object& summary, const py::object& update) const override {
+    PYBIND11_OVERRIDE_PURE_NAME(
+      py::object,          // Return type
+      tuple_policy,        // Parent class
+      "__call__",          // Name of function in python
+      operator(),          // Name of function in C++
+      summary, update      // Arguemnts
+    );
+  }
+};
+
+/* The tuple_policy_holder provides a concrete class that dispatches calls
+ * from the sketch to the tuple_policy. This class is needed to provide a
+ * concrete object to produce a compiled library, but library users should
+ * never need to use this directly.
+ */
+struct tuple_policy_holder {
+  explicit tuple_policy_holder(std::shared_ptr<tuple_policy> policy) : _policy(policy) {}
+  tuple_policy_holder(const tuple_policy_holder& other) : _policy(other._policy) {}
+  tuple_policy_holder(tuple_policy_holder&& other) : _policy(std::move(other._policy)) {}
+  tuple_policy_holder& operator=(const tuple_policy_holder& other) { _policy = other._policy; return *this; }
+  tuple_policy_holder& operator=(tuple_policy_holder&& other) { std::swap(_policy, other._policy); return *this; }
+
+  py::object create() const { return _policy->create_summary(); }
+  
+  void update(py::object& summary, const py::object& update) const {
+    summary = _policy->update_summary(summary, update);
+  }
+
+  void operator()(py::object& summary, const py::object& update) const {
+    summary = _policy->operator()(summary, update);
+  }
+
+  private:
+    std::shared_ptr<tuple_policy> _policy;
+};
+
+/* A degenerate policy used to enable Jaccard Similarity on tuple sketches,
+ * where the computation requires a union and intersection over the keys but
+ * does not need to observe the summaries.
+ */
+struct dummy_jaccard_policy {
+  void operator()(py::object&, const py::object&) const {
+    return;
+  }
+};
+
+}
+
+#endif // _TUPLE_POLICY_HPP_

--- a/python/src/datasketches.cpp
+++ b/python/src/datasketches.cpp
@@ -27,6 +27,7 @@ void init_kll(py::module& m);
 void init_fi(py::module& m);
 void init_cpc(py::module& m);
 void init_theta(py::module& m);
+void init_tuple(py::module& m);
 void init_vo(py::module& m);
 void init_req(py::module& m);
 void init_quantiles(py::module& m);
@@ -42,6 +43,7 @@ PYBIND11_MODULE(_datasketches, m) {
   init_fi(m);
   init_cpc(m);
   init_theta(m);
+  init_tuple(m);
   init_vo(m);
   init_req(m);
   init_quantiles(m);

--- a/python/src/py_serde.cpp
+++ b/python/src/py_serde.cpp
@@ -27,13 +27,14 @@
 namespace py = pybind11;
 
 void init_serde(py::module& m) {
-  py::class_<datasketches::py_object_serde, datasketches::PyObjectSerDe /* <--- trampoline*/>(m, "PyObjectSerDe")
+  using namespace datasketches;
+  py::class_<py_object_serde, PyObjectSerDe /* <--- trampoline*/>(m, "PyObjectSerDe")
     .def(py::init<>())
-    .def("get_size", &datasketches::py_object_serde::get_size, py::arg("item"),
+    .def("get_size", &py_object_serde::get_size, py::arg("item"),
         "Returns the size in bytes of an item")
-    .def("to_bytes", &datasketches::py_object_serde::to_bytes, py::arg("item"),
+    .def("to_bytes", &py_object_serde::to_bytes, py::arg("item"),
         "Retuns a bytes object with a serialized version of an item")
-    .def("from_bytes", &datasketches::py_object_serde::from_bytes, py::arg("data"), py::arg("offset"),
+    .def("from_bytes", &py_object_serde::from_bytes, py::arg("data"), py::arg("offset"),
         "Reads a bytes object starting from the given offest and returns a tuple of the reconstructed "
         "object and the number of additional bytes read")
     ;

--- a/python/src/theta_wrapper.cpp
+++ b/python/src/theta_wrapper.cpp
@@ -128,7 +128,7 @@ void init_theta(py::module &m) {
         "compute",
         &theta_a_not_b::compute<const theta_sketch&, const theta_sketch&>,
         py::arg("a"), py::arg("b"), py::arg("ordered")=true,
-        "Returns a sketch with the reuslt of appying the A-not-B operation on the given inputs"
+        "Returns a sketch with the result of appying the A-not-B operation on the given inputs"
     )
   ;
   

--- a/python/src/tuple_wrapper.cpp
+++ b/python/src/tuple_wrapper.cpp
@@ -63,7 +63,7 @@ void init_tuple(py::module &m) {
   using py_tuple_a_not_b = tuple_a_not_b<py::object>;
   using py_tuple_jaccard_similarity = jaccard_similarity_base<tuple_union<py::object, dummy_jaccard_policy>, tuple_intersection<py::object, dummy_jaccard_policy>, pair_extract_key<uint64_t, py::object>>;
 
-  py::class_<py_tuple_sketch>(m, "tuple_sketch")
+  py::class_<py_tuple_sketch>(m, "_tuple_sketch")
     .def("__str__", &py_tuple_sketch::to_string, py::arg("print_items")=false,
          "Produces a string summary of the sketch")
     .def("to_string", &py_tuple_sketch::to_string, py::arg("print_items")=false,
@@ -91,7 +91,7 @@ void init_tuple(py::module &m) {
     .def("__iter__", [](const py_tuple_sketch& s) { return py::make_iterator(s.begin(), s.end()); })
   ;
 
-  py::class_<py_compact_tuple, py_tuple_sketch>(m, "compact_tuple_sketch")
+  py::class_<py_compact_tuple, py_tuple_sketch>(m, "_compact_tuple_sketch")
     .def(py::init<const py_compact_tuple&>(), py::arg("other"))
     .def(py::init<const py_tuple_sketch&, bool>(), py::arg("other"), py::arg("ordered")=true)
     .def(py::init<const theta_sketch&, py::object&>(), py::arg("other"), py::arg("summary"),
@@ -106,10 +106,10 @@ void init_tuple(py::module &m) {
     )
     .def_static(
         "deserialize",
-        [](const std::string& bytes, uint64_t seed, py_object_serde& serde) {
+        [](const std::string& bytes, py_object_serde& serde, uint64_t seed) {
           return py_compact_tuple::deserialize(bytes.data(), bytes.size(), seed, serde);
         },
-        py::arg("bytes"), py::arg("seed")=DEFAULT_SEED, py::arg("serde"),
+        py::arg("bytes"), py::arg("serde"), py::arg("seed")=DEFAULT_SEED,
         "Reads a bytes object and returns the corresponding compact_tuple_sketch"
     );
 
@@ -176,7 +176,7 @@ void init_tuple(py::module &m) {
     )
   ;
 
-  py::class_<py_tuple_jaccard_similarity>(m, "tuple_jaccard_similarity")
+  py::class_<py_tuple_jaccard_similarity>(m, "_tuple_jaccard_similarity")
     .def_static(
         "jaccard",
         [](const py_tuple_sketch& sketch_a, const py_tuple_sketch& sketch_b, uint64_t seed) {

--- a/python/src/tuple_wrapper.cpp
+++ b/python/src/tuple_wrapper.cpp
@@ -113,13 +113,13 @@ void init_tuple(py::module &m) {
         "Reads a bytes object and returns the corresponding compact_tuple_sketch"
     );
 
-  py::class_<py_update_tuple, py_tuple_sketch>(m, "update_tuple_sketch")
+  py::class_<py_update_tuple, py_tuple_sketch>(m, "_update_tuple_sketch")
     .def(
-        py::init([](uint8_t lg_k, std::shared_ptr<tuple_policy> policy, double p, uint64_t seed) {
+        py::init([](std::shared_ptr<tuple_policy> policy, uint8_t lg_k, double p, uint64_t seed) {
           tuple_policy_holder holder(policy);
           return py_update_tuple::builder(holder).set_lg_k(lg_k).set_p(p).set_seed(seed).build();
         }),
-        py::arg("lg_k")=theta_constants::DEFAULT_LG_K, py::arg("policy"), py::arg("p")=1.0, py::arg("seed")=DEFAULT_SEED
+        py::arg("policy"), py::arg("lg_k")=theta_constants::DEFAULT_LG_K, py::arg("p")=1.0, py::arg("seed")=DEFAULT_SEED
     )
     .def(py::init<const py_update_tuple&>())
     .def("update", static_cast<void (py_update_tuple::*)(int64_t, py::object&)>(&py_update_tuple::update),
@@ -135,13 +135,13 @@ void init_tuple(py::module &m) {
          "Returns a compacted form of the sketch, optionally sorting it")
   ;
 
-  py::class_<py_tuple_union>(m, "tuple_union")
+  py::class_<py_tuple_union>(m, "_tuple_union")
     .def(
-        py::init([](uint8_t lg_k, std::shared_ptr<tuple_policy> policy, double p, uint64_t seed) {
+        py::init([](std::shared_ptr<tuple_policy> policy, uint8_t lg_k, double p, uint64_t seed) {
           tuple_policy_holder holder(policy);
           return py_tuple_union::builder(holder).set_lg_k(lg_k).set_p(p).set_seed(seed).build();
         }),
-        py::arg("lg_k")=theta_constants::DEFAULT_LG_K, py::arg("policy"), py::arg("p")=1.0, py::arg("seed")=DEFAULT_SEED
+        py::arg("policy"), py::arg("lg_k")=theta_constants::DEFAULT_LG_K, py::arg("p")=1.0, py::arg("seed")=DEFAULT_SEED
     )
     .def("update", &py_tuple_union::update<const py_tuple_sketch&>, py::arg("sketch"),
          "Updates the union with the given sketch")
@@ -151,13 +151,13 @@ void init_tuple(py::module &m) {
          "Resets the sketch to the initial empty")
   ;
 
-  py::class_<py_tuple_intersection>(m, "tuple_intersection")
+  py::class_<py_tuple_intersection>(m, "_tuple_intersection")
     .def(
-        py::init([](uint64_t seed, std::shared_ptr<tuple_policy> policy) {
+        py::init([](std::shared_ptr<tuple_policy> policy, uint64_t seed) {
           tuple_policy_holder holder(policy);
           return py_tuple_intersection(seed, holder);
         }),
-        py::arg("seed")=DEFAULT_SEED, py::arg("policy"))
+        py::arg("policy"), py::arg("seed")=DEFAULT_SEED)
     .def("update", &py_tuple_intersection::update<const py_tuple_sketch&>, py::arg("sketch"),
          "Intersections the provided sketch with the current intersection state")
     .def("get_result", &py_tuple_intersection::get_result, py::arg("ordered")=true,
@@ -166,7 +166,7 @@ void init_tuple(py::module &m) {
          "Returns True if the intersection has a valid result, otherwise False")
   ;
 
-  py::class_<py_tuple_a_not_b>(m, "tuple_a_not_b")
+  py::class_<py_tuple_a_not_b>(m, "_tuple_a_not_b")
     .def(py::init<uint64_t>(), py::arg("seed")=DEFAULT_SEED)
     .def(
         "compute",

--- a/python/src/tuple_wrapper.cpp
+++ b/python/src/tuple_wrapper.cpp
@@ -25,7 +25,7 @@
 #include "tuple_union.hpp"
 #include "tuple_intersection.hpp"
 #include "tuple_a_not_b.hpp"
-#include "tuple_jaccard_similarity.hpp"
+#include "theta_jaccard_similarity_base.hpp"
 #include "common_defs.hpp"
 
 #include "py_serde.hpp"
@@ -95,6 +95,12 @@ struct tuple_policy_holder {
     std::shared_ptr<tuple_policy> _policy;
 };
 
+struct dummy_jaccard_policy {
+  void operator()(py::object&, const py::object&) const {
+    return;
+  }
+};
+
 }
 
 void init_tuple(py::module &m) {
@@ -124,6 +130,7 @@ void init_tuple(py::module &m) {
   using py_tuple_union = tuple_union<py::object, tuple_policy_holder>;
   using py_tuple_intersection = tuple_intersection<py::object, tuple_policy_holder>;
   using py_tuple_a_not_b = tuple_a_not_b<py::object>;
+  using py_tuple_jaccard_similarity = jaccard_similarity_base<tuple_union<py::object, dummy_jaccard_policy>, tuple_intersection<py::object, dummy_jaccard_policy>, pair_extract_key<uint64_t, py::object>>;
 
   py::class_<py_tuple_sketch>(m, "tuple_sketch")
     .def("__str__", &py_tuple_sketch::to_string, py::arg("print_items")=false,
@@ -236,8 +243,7 @@ void init_tuple(py::module &m) {
     )
   ;
 
-  /*
-  py::class_<py_tuple_jaccard_similarity>(m, "theta_jaccard_similarity")
+  py::class_<py_tuple_jaccard_similarity>(m, "tuple_jaccard_similarity")
     .def_static(
         "jaccard",
         [](const py_tuple_sketch& sketch_a, const py_tuple_sketch& sketch_b, uint64_t seed) {
@@ -268,5 +274,4 @@ void init_tuple(py::module &m) {
         "to be dissimilar sith a confidence of 97.7% and returns True, otherwise False."
     )
   ;
-  */
 }

--- a/python/src/tuple_wrapper.cpp
+++ b/python/src/tuple_wrapper.cpp
@@ -232,7 +232,7 @@ void init_tuple(py::module &m) {
         "compute",
         &py_tuple_a_not_b::compute<const py_tuple_sketch&, const py_tuple_sketch&>,
         py::arg("a"), py::arg("b"), py::arg("ordered")=true,
-        "Returns a sketch with the reuslt of appying the A-not-B operation on the given inputs"
+        "Returns a sketch with the result of appying the A-not-B operation on the given inputs"
     )
   ;
 

--- a/python/src/tuple_wrapper.cpp
+++ b/python/src/tuple_wrapper.cpp
@@ -118,41 +118,44 @@ void init_tuple(py::module &m) {
          "Updates the provided summary using the data in update")
   ;
 
-  using py_tuple = tuple_sketch<py::object>;
+  using py_tuple_sketch = tuple_sketch<py::object>;
   using py_update_tuple = update_tuple_sketch<py::object, py::object, tuple_policy_holder>;
   using py_compact_tuple = compact_tuple_sketch<py::object>;
+  using py_tuple_union = tuple_union<py::object, tuple_policy_holder>;
+  using py_tuple_intersection = tuple_intersection<py::object, tuple_policy_holder>;
+  using py_tuple_a_not_b = tuple_a_not_b<py::object>;
 
-  py::class_<py_tuple>(m, "tuple_sketch")
-    .def("__str__", &py_tuple::to_string, py::arg("print_items")=false,
+  py::class_<py_tuple_sketch>(m, "tuple_sketch")
+    .def("__str__", &py_tuple_sketch::to_string, py::arg("print_items")=false,
          "Produces a string summary of the sketch")
-    .def("to_string", &py_tuple::to_string, py::arg("print_items")=false,
+    .def("to_string", &py_tuple_sketch::to_string, py::arg("print_items")=false,
          "Produces a string summary of the sketch")
-    .def("is_empty", &py_tuple::is_empty,
+    .def("is_empty", &py_tuple_sketch::is_empty,
          "Returns True if the sketch is empty, otherwise False")
-    .def("get_estimate", &py_tuple::get_estimate,
+    .def("get_estimate", &py_tuple_sketch::get_estimate,
          "Estimate of the distinct count of the input stream")
-    .def("get_upper_bound", static_cast<double (py_tuple::*)(uint8_t) const>(&py_tuple::get_upper_bound), py::arg("num_std_devs"),
+    .def("get_upper_bound", static_cast<double (py_tuple_sketch::*)(uint8_t) const>(&py_tuple_sketch::get_upper_bound), py::arg("num_std_devs"),
          "Returns an approximate upper bound on the estimate at standard deviations in {1, 2, 3}")
-    .def("get_lower_bound", static_cast<double (py_tuple::*)(uint8_t) const>(&py_tuple::get_lower_bound), py::arg("num_std_devs"),
+    .def("get_lower_bound", static_cast<double (py_tuple_sketch::*)(uint8_t) const>(&py_tuple_sketch::get_lower_bound), py::arg("num_std_devs"),
          "Returns an approximate lower bound on the estimate at standard deviations in {1, 2, 3}")
-    .def("is_estimation_mode", &py_tuple::is_estimation_mode,
+    .def("is_estimation_mode", &py_tuple_sketch::is_estimation_mode,
          "Returns True if sketch is in estimation mode, otherwise False")
-    .def("get_theta", &py_tuple::get_theta,
+    .def("get_theta", &py_tuple_sketch::get_theta,
          "Returns theta (effective sampling rate) as a fraction from 0 to 1")
-    .def("get_theta64", &py_tuple::get_theta64,
+    .def("get_theta64", &py_tuple_sketch::get_theta64,
          "Returns theta as 64-bit value")
-    .def("get_num_retained", &py_tuple::get_num_retained,
+    .def("get_num_retained", &py_tuple_sketch::get_num_retained,
          "Retunrs the number of items currently in the sketch")
-    .def("get_seed_hash", [](const py_tuple& sk) { return sk.get_seed_hash(); }, // why does regular call not work??
+    .def("get_seed_hash", [](const py_tuple_sketch& sk) { return sk.get_seed_hash(); }, // why does regular call not work??
          "Returns a hash of the seed used in the sketch")
-    .def("is_ordered", &py_tuple::is_ordered,
+    .def("is_ordered", &py_tuple_sketch::is_ordered,
          "Returns True if the sketch entries are sorted, otherwise False")
-    .def("__iter__", [](const py_tuple& s) { return py::make_iterator(s.begin(), s.end()); })
+    .def("__iter__", [](const py_tuple_sketch& s) { return py::make_iterator(s.begin(), s.end()); })
   ;
 
-  py::class_<py_compact_tuple, py_tuple>(m, "compact_tuple_sketch")
+  py::class_<py_compact_tuple, py_tuple_sketch>(m, "compact_tuple_sketch")
     .def(py::init<const py_compact_tuple&>())
-    .def(py::init<const py_tuple&, bool>())
+    .def(py::init<const py_tuple_sketch&, bool>())
     .def(
         "serialize",
         [](const py_compact_tuple& sk, py_object_serde& serde) {
@@ -170,7 +173,7 @@ void init_tuple(py::module &m) {
         "Reads a bytes object and returns the corresponding compact_tuple_sketch"
     );
 
-  py::class_<py_update_tuple, py_tuple>(m, "update_tuple_sketch")
+  py::class_<py_update_tuple, py_tuple_sketch>(m, "update_tuple_sketch")
     .def(
         py::init([](uint8_t lg_k, std::shared_ptr<tuple_policy> policy, double p, uint64_t seed) {
           tuple_policy_holder holder(policy);
@@ -179,79 +182,86 @@ void init_tuple(py::module &m) {
         py::arg("lg_k")=theta_constants::DEFAULT_LG_K, py::arg("policy"), py::arg("p")=1.0, py::arg("seed")=DEFAULT_SEED
     )
     .def(py::init<const py_update_tuple&>())
-    .def("update", (void (py_update_tuple::*)(int64_t, py::object&)) &py_update_tuple::update,
+    .def("update", static_cast<void (py_update_tuple::*)(int64_t, py::object&)>(&py_update_tuple::update),
          py::arg("datum"), py::arg("summary"),
          "Updates the sketch with the given integral value")
-    .def("update", (void (py_update_tuple::*)(double, py::object&)) &py_update_tuple::update,
+    .def("update", static_cast<void (py_update_tuple::*)(double, py::object&)>(&py_update_tuple::update),
          py::arg("datum"), py::arg("summary"),
          "Updates the sketch with the given floating point value")
-    .def("update", (void (py_update_tuple::*)(const std::string&, py::object&)) &py_update_tuple::update,
+    .def("update", static_cast<void (py_update_tuple::*)(const std::string&, py::object&)>(&py_update_tuple::update),
          py::arg("datum"), py::arg("summary"),
          "Updates the sketch with the given string")
     .def("compact", &py_update_tuple::compact, py::arg("ordered")=true,
          "Returns a compacted form of the sketch, optionally sorting it")
   ;
 
-/*
-  py::class_<theta_union>(m, "theta_union")
+  py::class_<py_tuple_union>(m, "tuple_union")
     .def(
-        py::init([](uint8_t lg_k, double p, uint64_t seed) {
-          return theta_union::builder().set_lg_k(lg_k).set_p(p).set_seed(seed).build();
+        py::init([](uint8_t lg_k, std::shared_ptr<tuple_policy> policy, double p, uint64_t seed) {
+          tuple_policy_holder holder(policy);
+          return py_tuple_union::builder(holder).set_lg_k(lg_k).set_p(p).set_seed(seed).build();
         }),
-        py::arg("lg_k")=theta_constants::DEFAULT_LG_K, py::arg("p")=1.0, py::arg("seed")=DEFAULT_SEED
+        py::arg("lg_k")=theta_constants::DEFAULT_LG_K, py::arg("policy"), py::arg("p")=1.0, py::arg("seed")=DEFAULT_SEED
     )
-    .def("update", &theta_union::update<const theta_sketch&>, py::arg("sketch"),
+    .def("update", &py_tuple_union::update<const py_tuple_sketch&>, py::arg("sketch"),
          "Updates the union with the given sketch")
-    .def("get_result", &theta_union::get_result, py::arg("ordered")=true,
+    .def("get_result", &py_tuple_union::get_result, py::arg("ordered")=true,
          "Returns the sketch corresponding to the union result")
+    .def("reset", &py_tuple_union::reset,
+         "Resets the sketch to the initial empty")
   ;
 
-  py::class_<theta_intersection>(m, "theta_intersection")
-    .def(py::init<uint64_t>(), py::arg("seed")=DEFAULT_SEED)
-    .def(py::init<const theta_intersection&>())
-    .def("update", &theta_intersection::update<const theta_sketch&>, py::arg("sketch"),
+  py::class_<py_tuple_intersection>(m, "tuple_intersection")
+    .def(
+        py::init([](uint64_t seed, std::shared_ptr<tuple_policy> policy) {
+          tuple_policy_holder holder(policy);
+          return py_tuple_intersection(seed, holder);
+        }),
+        py::arg("seed")=DEFAULT_SEED, py::arg("policy"))
+    .def("update", &py_tuple_intersection::update<const py_tuple_sketch&>, py::arg("sketch"),
          "Intersections the provided sketch with the current intersection state")
-    .def("get_result", &theta_intersection::get_result, py::arg("ordered")=true,
+    .def("get_result", &py_tuple_intersection::get_result, py::arg("ordered")=true,
          "Returns the sketch corresponding to the intersection result")
-    .def("has_result", &theta_intersection::has_result,
+    .def("has_result", &py_tuple_intersection::has_result,
          "Returns True if the intersection has a valid result, otherwise False")
   ;
 
-  py::class_<theta_a_not_b>(m, "theta_a_not_b")
+  py::class_<py_tuple_a_not_b>(m, "tuple_a_not_b")
     .def(py::init<uint64_t>(), py::arg("seed")=DEFAULT_SEED)
     .def(
         "compute",
-        &theta_a_not_b::compute<const theta_sketch&, const theta_sketch&>,
+        &py_tuple_a_not_b::compute<const py_tuple_sketch&, const py_tuple_sketch&>,
         py::arg("a"), py::arg("b"), py::arg("ordered")=true,
         "Returns a sketch with the reuslt of appying the A-not-B operation on the given inputs"
     )
   ;
-  
-  py::class_<theta_jaccard_similarity>(m, "theta_jaccard_similarity")
+
+  /*
+  py::class_<py_tuple_jaccard_similarity>(m, "theta_jaccard_similarity")
     .def_static(
         "jaccard",
-        [](const theta_sketch& sketch_a, const theta_sketch& sketch_b, uint64_t seed) {
-          return theta_jaccard_similarity::jaccard(sketch_a, sketch_b, seed);
+        [](const py_tuple_sketch& sketch_a, const py_tuple_sketch& sketch_b, uint64_t seed) {
+          return py_tuple_jaccard_similarity::jaccard(sketch_a, sketch_b, seed);
         },
         py::arg("sketch_a"), py::arg("sketch_b"), py::arg("seed")=DEFAULT_SEED,
         "Returns a list with {lower_bound, estimate, upper_bound} of the Jaccard similarity between sketches"
     )
     .def_static(
         "exactly_equal",
-        &theta_jaccard_similarity::exactly_equal<const theta_sketch&, const theta_sketch&>,
+        &py_tuple_jaccard_similarity::exactly_equal<const py_tuple_sketch&, const py_tuple_sketch&>,
         py::arg("sketch_a"), py::arg("sketch_b"), py::arg("seed")=DEFAULT_SEED,
         "Returns True if sketch_a and sketch_b are equivalent, otherwise False"
     )
     .def_static(
         "similarity_test",
-        &theta_jaccard_similarity::similarity_test<const theta_sketch&, const theta_sketch&>,
+        &py_tuple_jaccard_similarity::similarity_test<const py_tuple_sketch&, const py_tuple_sketch&>,
         py::arg("actual"), py::arg("expected"), py::arg("threshold"), py::arg("seed")=DEFAULT_SEED,
         "Tests similarity of an actual sketch against an expected sketch. Computers the lower bound of the Jaccard "
         "index J_{LB} of the actual and expected sketches. If J_{LB} >= threshold, then the sketches are considered "
         "to be similar sith a confidence of 97.7% and returns True, otherwise False.")
     .def_static(
         "dissimilarity_test",
-        &theta_jaccard_similarity::dissimilarity_test<const theta_sketch&, const theta_sketch&>,
+        &py_tuple_jaccard_similarity::dissimilarity_test<const py_tuple_sketch&, const py_tuple_sketch&>,
         py::arg("actual"), py::arg("expected"), py::arg("threshold"), py::arg("seed")=DEFAULT_SEED,
         "Tests dissimilarity of an actual sketch against an expected sketch. Computers the lower bound of the Jaccard "
         "index J_{UB} of the actual and expected sketches. If J_{UB} <= threshold, then the sketches are considered "

--- a/python/src/tuple_wrapper.cpp
+++ b/python/src/tuple_wrapper.cpp
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <memory>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "tuple_sketch.hpp"
+#include "tuple_union.hpp"
+#include "tuple_intersection.hpp"
+#include "tuple_a_not_b.hpp"
+#include "tuple_jaccard_similarity.hpp"
+#include "common_defs.hpp"
+
+#include "py_serde.hpp"
+
+namespace py = pybind11;
+
+namespace datasketches {
+
+struct tuple_policy {
+  virtual py::object create_summary() const = 0;
+  virtual py::object update_summary(py::object& summary, const py::object& update) const = 0;
+  virtual ~tuple_policy() = default;
+};
+
+struct TuplePolicy : public tuple_policy {
+  using tuple_policy::tuple_policy;
+
+  // trampoline definitions -- need one for each virtual function
+  py::object create_summary() const override {
+    PYBIND11_OVERRIDE_PURE(
+      py::object,          // Return type
+      tuple_policy,        // Parent class
+      create_summary,      // Name of function in C++ (must match Python name)
+                           // Argument(s) -- if any
+    );
+  }
+
+  py::object update_summary(py::object& summary, const py::object& update) const override {
+    PYBIND11_OVERRIDE_PURE(
+      py::object,          // Return type
+      tuple_policy,        // Parent class
+      update_summary,      // Name of function in C++ (must match Python name)
+      summary, update      // Argument(s)
+    );
+  }
+};
+
+struct tuple_policy_holder {
+  explicit tuple_policy_holder(std::shared_ptr<tuple_policy> policy) : _policy(policy) {}
+  tuple_policy_holder(const tuple_policy_holder& other) : _policy(other._policy) {}
+  tuple_policy_holder(tuple_policy_holder&& other) : _policy(std::move(other._policy)) {}
+  tuple_policy_holder& operator=(const tuple_policy_holder& other) { _policy = other._policy; return *this; }
+  tuple_policy_holder& operator=(tuple_policy_holder&& other) { std::swap(_policy, other._policy); return *this; }
+
+  py::object create() const { return _policy->create_summary(); }
+  
+  void update(py::object& summary, const py::object& update) const {
+    summary = _policy->update_summary(summary, update);
+  }
+
+  private:
+    std::shared_ptr<tuple_policy> _policy;
+};
+
+}
+
+void init_tuple(py::module &m) {
+  using namespace datasketches;
+
+  py::class_<tuple_policy, TuplePolicy, std::shared_ptr<tuple_policy>>(m, "TuplePolicy")
+    .def(py::init())
+    .def("create_summary", &tuple_policy::create_summary)
+    .def("update_summary", &tuple_policy::update_summary, py::arg("summary"), py::arg("update"))
+  ;
+
+  // only needed temporarily -- can remove once everything is working
+  py::class_<tuple_policy_holder>(m, "TuplePolicyHolder")
+    .def(py::init<std::shared_ptr<tuple_policy>>())
+    .def("create", &tuple_policy_holder::create, "Creates a new Summary object")
+    .def("update", &tuple_policy_holder::update, py::arg("summary"), py::arg("update"),
+         "Updates the provided summary using the data in update")
+  ;
+
+  using py_tuple = tuple_sketch<py::object>;
+  using py_update_tuple = update_tuple_sketch<py::object, py::object, tuple_policy_holder>;
+  using py_compact_tuple = compact_tuple_sketch<py::object>;
+
+  py::class_<py_tuple>(m, "tuple_sketch")
+    .def("__str__", &py_tuple::to_string, py::arg("print_items")=false,
+         "Produces a string summary of the sketch")
+    .def("to_string", &py_tuple::to_string, py::arg("print_items")=false,
+         "Produces a string summary of the sketch")
+    .def("is_empty", &py_tuple::is_empty,
+         "Returns True if the sketch is empty, otherwise False")
+    .def("get_estimate", &py_tuple::get_estimate,
+         "Estimate of the distinct count of the input stream")
+    .def("get_upper_bound", static_cast<double (py_tuple::*)(uint8_t) const>(&py_tuple::get_upper_bound), py::arg("num_std_devs"),
+         "Returns an approximate upper bound on the estimate at standard deviations in {1, 2, 3}")
+    .def("get_lower_bound", static_cast<double (py_tuple::*)(uint8_t) const>(&py_tuple::get_lower_bound), py::arg("num_std_devs"),
+         "Returns an approximate lower bound on the estimate at standard deviations in {1, 2, 3}")
+    .def("is_estimation_mode", &py_tuple::is_estimation_mode,
+         "Returns True if sketch is in estimation mode, otherwise False")
+    .def("get_theta", &py_tuple::get_theta,
+         "Returns theta (effective sampling rate) as a fraction from 0 to 1")
+    .def("get_theta64", &py_tuple::get_theta64,
+         "Returns theta as 64-bit value")
+    .def("get_num_retained", &py_tuple::get_num_retained,
+         "Retunrs the number of items currently in the sketch")
+    .def("get_seed_hash", [](const py_tuple& sk) { return sk.get_seed_hash(); }, // why does regular call not work??
+         "Returns a hash of the seed used in the sketch")
+    .def("is_ordered", &py_tuple::is_ordered,
+         "Returns True if the sketch entries are sorted, otherwise False")
+    .def("__iter__", [](const py_tuple& s) { return py::make_iterator(s.begin(), s.end()); })
+  ;
+
+  py::class_<py_compact_tuple, py_tuple>(m, "compact_tuple_sketch")
+    .def(py::init<const py_compact_tuple&>())
+    .def(py::init<const py_tuple&, bool>())
+    .def(
+        "serialize",
+        [](const py_compact_tuple& sk, py_object_serde& serde) {
+          auto bytes = sk.serialize(0, serde);
+          return py::bytes(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+        }, py::arg("serde"),
+        "Serializes the sketch into a bytes object"
+    )
+    .def_static(
+        "deserialize",
+        [](const std::string& bytes, uint64_t seed, py_object_serde& serde) {
+          return py_compact_tuple::deserialize(bytes.data(), bytes.size(), seed, serde);
+        },
+        py::arg("bytes"), py::arg("seed")=DEFAULT_SEED, py::arg("serde"),
+        "Reads a bytes object and returns the corresponding compact_tuple_sketch"
+    );
+
+  py::class_<py_update_tuple, py_tuple>(m, "update_tuple_sketch")
+    .def(
+        py::init([](uint8_t lg_k, std::shared_ptr<tuple_policy> policy, double p, uint64_t seed) {
+          tuple_policy_holder holder(policy);
+          return py_update_tuple::builder(holder).set_lg_k(lg_k).set_p(p).set_seed(seed).build();
+        }),
+        py::arg("lg_k")=theta_constants::DEFAULT_LG_K, py::arg("policy"), py::arg("p")=1.0, py::arg("seed")=DEFAULT_SEED
+    )
+    .def(py::init<const py_update_tuple&>())
+    .def("update", (void (py_update_tuple::*)(int64_t, py::object&)) &py_update_tuple::update,
+         py::arg("datum"), py::arg("summary"),
+         "Updates the sketch with the given integral value")
+    .def("update", (void (py_update_tuple::*)(double, py::object&)) &py_update_tuple::update,
+         py::arg("datum"), py::arg("summary"),
+         "Updates the sketch with the given floating point value")
+    .def("update", (void (py_update_tuple::*)(const std::string&, py::object&)) &py_update_tuple::update,
+         py::arg("datum"), py::arg("summary"),
+         "Updates the sketch with the given string")
+    .def("compact", &py_update_tuple::compact, py::arg("ordered")=true,
+         "Returns a compacted form of the sketch, optionally sorting it")
+  ;
+
+/*
+  py::class_<theta_union>(m, "theta_union")
+    .def(
+        py::init([](uint8_t lg_k, double p, uint64_t seed) {
+          return theta_union::builder().set_lg_k(lg_k).set_p(p).set_seed(seed).build();
+        }),
+        py::arg("lg_k")=theta_constants::DEFAULT_LG_K, py::arg("p")=1.0, py::arg("seed")=DEFAULT_SEED
+    )
+    .def("update", &theta_union::update<const theta_sketch&>, py::arg("sketch"),
+         "Updates the union with the given sketch")
+    .def("get_result", &theta_union::get_result, py::arg("ordered")=true,
+         "Returns the sketch corresponding to the union result")
+  ;
+
+  py::class_<theta_intersection>(m, "theta_intersection")
+    .def(py::init<uint64_t>(), py::arg("seed")=DEFAULT_SEED)
+    .def(py::init<const theta_intersection&>())
+    .def("update", &theta_intersection::update<const theta_sketch&>, py::arg("sketch"),
+         "Intersections the provided sketch with the current intersection state")
+    .def("get_result", &theta_intersection::get_result, py::arg("ordered")=true,
+         "Returns the sketch corresponding to the intersection result")
+    .def("has_result", &theta_intersection::has_result,
+         "Returns True if the intersection has a valid result, otherwise False")
+  ;
+
+  py::class_<theta_a_not_b>(m, "theta_a_not_b")
+    .def(py::init<uint64_t>(), py::arg("seed")=DEFAULT_SEED)
+    .def(
+        "compute",
+        &theta_a_not_b::compute<const theta_sketch&, const theta_sketch&>,
+        py::arg("a"), py::arg("b"), py::arg("ordered")=true,
+        "Returns a sketch with the reuslt of appying the A-not-B operation on the given inputs"
+    )
+  ;
+  
+  py::class_<theta_jaccard_similarity>(m, "theta_jaccard_similarity")
+    .def_static(
+        "jaccard",
+        [](const theta_sketch& sketch_a, const theta_sketch& sketch_b, uint64_t seed) {
+          return theta_jaccard_similarity::jaccard(sketch_a, sketch_b, seed);
+        },
+        py::arg("sketch_a"), py::arg("sketch_b"), py::arg("seed")=DEFAULT_SEED,
+        "Returns a list with {lower_bound, estimate, upper_bound} of the Jaccard similarity between sketches"
+    )
+    .def_static(
+        "exactly_equal",
+        &theta_jaccard_similarity::exactly_equal<const theta_sketch&, const theta_sketch&>,
+        py::arg("sketch_a"), py::arg("sketch_b"), py::arg("seed")=DEFAULT_SEED,
+        "Returns True if sketch_a and sketch_b are equivalent, otherwise False"
+    )
+    .def_static(
+        "similarity_test",
+        &theta_jaccard_similarity::similarity_test<const theta_sketch&, const theta_sketch&>,
+        py::arg("actual"), py::arg("expected"), py::arg("threshold"), py::arg("seed")=DEFAULT_SEED,
+        "Tests similarity of an actual sketch against an expected sketch. Computers the lower bound of the Jaccard "
+        "index J_{LB} of the actual and expected sketches. If J_{LB} >= threshold, then the sketches are considered "
+        "to be similar sith a confidence of 97.7% and returns True, otherwise False.")
+    .def_static(
+        "dissimilarity_test",
+        &theta_jaccard_similarity::dissimilarity_test<const theta_sketch&, const theta_sketch&>,
+        py::arg("actual"), py::arg("expected"), py::arg("threshold"), py::arg("seed")=DEFAULT_SEED,
+        "Tests dissimilarity of an actual sketch against an expected sketch. Computers the lower bound of the Jaccard "
+        "index J_{UB} of the actual and expected sketches. If J_{UB} <= threshold, then the sketches are considered "
+        "to be dissimilar sith a confidence of 97.7% and returns True, otherwise False."
+    )
+  ;
+  */
+}

--- a/python/src/tuple_wrapper.cpp
+++ b/python/src/tuple_wrapper.cpp
@@ -21,6 +21,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "theta_sketch.hpp"
 #include "tuple_sketch.hpp"
 #include "tuple_union.hpp"
 #include "tuple_intersection.hpp"
@@ -163,6 +164,8 @@ void init_tuple(py::module &m) {
   py::class_<py_compact_tuple, py_tuple_sketch>(m, "compact_tuple_sketch")
     .def(py::init<const py_compact_tuple&>())
     .def(py::init<const py_tuple_sketch&, bool>())
+    .def(py::init<const theta_sketch&, py::object&>(),
+         "Creates a compact tuple sketch from a theta sketch using a fixed summary value.")
     .def(
         "serialize",
         [](const py_compact_tuple& sk, py_object_serde& serde) {

--- a/python/tests/tuple_test.py
+++ b/python/tests/tuple_test.py
@@ -32,7 +32,7 @@ class TupleTest(unittest.TestCase):
 
         # create a sketch and inject some values -- summary is 2 so we can sum them
         # and know the reuslt
-        sk = self.generate_tuple_sketch(AccumulatorPolicy(), n, k, summary=2)
+        sk = self.generate_tuple_sketch(AccumulatorPolicy(), n, k, value=2)
 
         # we can check that the upper and lower bounds bracket the
         # estimate, without needing to know the exact value.
@@ -84,8 +84,8 @@ class TupleTest(unittest.TestCase):
         offset = int(3 * n / 4) # it's a float w/o cast
 
         # create a couple sketches and inject some values, with different summaries
-        sk1 = self.generate_tuple_sketch(AccumulatorPolicy(), n, k, summary=5)
-        sk2 = self.generate_tuple_sketch(AccumulatorPolicy(), n, k, summary=7, offset=offset)
+        sk1 = self.generate_tuple_sketch(AccumulatorPolicy(), n, k, value=5)
+        sk2 = self.generate_tuple_sketch(AccumulatorPolicy(), n, k, value=7, offset=offset)
 
         # UNIONS
         # create a union object
@@ -195,11 +195,11 @@ class TupleTest(unittest.TestCase):
         self.assertTrue(tuple_jaccard_similarity.similarity_test(sk1, result, 0.7))
 
 
-    # Generates a basic tuple sketch using a fixed integer summary of 2
-    def generate_tuple_sketch(self, policy, n, k, summary, offset=0):
+    # Generates a basic tuple sketch with a fixed value for each update
+    def generate_tuple_sketch(self, policy, n, k, value, offset=0):
       sk = update_tuple_sketch(policy, k)
       for i in range(0, n):
-        sk.update(i + offset, summary)
+        sk.update(i + offset, value)
       return sk
         
 if __name__ == '__main__':

--- a/python/tests/tuple_test.py
+++ b/python/tests/tuple_test.py
@@ -1,0 +1,210 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+ 
+import unittest
+
+from datasketches import update_tuple_sketch
+from datasketches import compact_tuple_sketch, tuple_union
+from datasketches import tuple_intersection, tuple_a_not_b
+from datasketches import tuple_jaccard_similarity
+from datasketches import tuple_jaccard_similarity, PyIntsSerDe
+from datasketches import AccumulatorPolicy, MaxIntPolicy, MinIntPolicy
+from datasketches import update_theta_sketch
+
+class TupleTest(unittest.TestCase):
+    def test_tuple_basic_example(self):
+        k = 12      # 2^k = 4096 rows in the table
+        n = 1 << 18 # ~256k unique values
+
+        # create a sketch and inject some values -- summary is 2 so we can sum them
+        # and know the reuslt
+        sk = self.generate_tuple_sketch(n, k, summary=2, policy=AccumulatorPolicy())
+
+        # we can check that the upper and lower bounds bracket the
+        # estimate, without needing to know the exact value.
+        self.assertLessEqual(sk.get_lower_bound(1), sk.get_estimate())
+        self.assertGreaterEqual(sk.get_upper_bound(1), sk.get_estimate())
+
+        # because this sketch is deterministically generated, we can
+        # also compare against the exact value
+        self.assertLessEqual(sk.get_lower_bound(1), n)
+        self.assertGreaterEqual(sk.get_upper_bound(1), n)
+
+        # compact and serialize for storage, then reconstruct
+        sk_bytes = sk.compact().serialize(PyIntsSerDe())
+        new_sk = compact_tuple_sketch.deserialize(sk_bytes, serde=PyIntsSerDe())
+
+        # estimate remains unchanged
+        self.assertFalse(sk.is_empty())
+        self.assertEqual(sk.get_estimate(), new_sk.get_estimate())
+
+        # we can also iterate over the sketch entries
+        # the iterator provides a (hashkey, summary) pair where the
+        # first value is the raw hash value and the second the summary
+        count = 0
+        cumSum = 0
+        for pair in new_sk:
+          self.assertLess(pair[0], new_sk.get_theta64())
+          count += 1
+          cumSum += pair[1]
+        self.assertEqual(count, new_sk.get_num_retained())
+        self.assertEqual(cumSum, 2 * new_sk.get_num_retained())
+
+        # we can even create a tuple sketch from an existing theta sketch
+        # as long as we provide a summary to use
+        theta_sk = update_theta_sketch(k)
+        for i in range(n, 2*n):
+          theta_sk.update(i)
+        cts = compact_tuple_sketch(theta_sk, 5)
+        cumSum = 0
+        for pair in cts:
+          cumSum += pair[1]
+        self.assertEqual(cumSum, 5 * cts.get_num_retained())
+
+
+    def test_tuple_set_operations(self):
+        k = 12      # 2^k = 4096 rows in the table
+        n = 1 << 18 # ~256k unique values
+
+        # we'll have 1/4 of the values overlap
+        offset = int(3 * n / 4) # it's a float w/o cast
+
+        # create a couple sketches and inject some values, with different summaries
+        sk1 = self.generate_tuple_sketch(n, k, summary=5, policy=AccumulatorPolicy())
+        sk2 = self.generate_tuple_sketch(n, k, summary=7, policy=AccumulatorPolicy(), offset=offset)
+
+        # UNIONS
+        # create a union object
+        maxIntPolicy = MaxIntPolicy()
+        union = tuple_union(k, policy=maxIntPolicy)
+        union.update(sk1)
+        union.update(sk2)
+
+        # getting result from union returns a compact_theta_sketch
+        # compact theta sketches can be used in additional unions
+        # or set operations but cannot accept further item updates
+        result = union.get_result()
+        self.assertTrue(isinstance(result, compact_tuple_sketch))
+
+        # since our process here is deterministic, we have
+        # checked and know the exact answer is within one
+        # standard deviation of the estimate
+        self.assertLessEqual(result.get_lower_bound(1), 7 * n / 4)
+        self.assertGreaterEqual(result.get_upper_bound(1), 7 * n / 4)
+
+        # we unioned two equal-sized sketches with overlap and used
+        # the max value as the resulting summary, meaning we should
+        # have more summaries with value 7 than value 5 in the result
+        count5 = 0
+        count7 = 0
+        for pair in result:
+          if pair[1] == 5:
+            count5 += 1
+          elif pair[1] == 7:
+            count7 += 1
+          else:
+            self.fail()
+        self.assertLess(count5, count7)
+
+        # INTERSECTIONS
+        # create an intersection object
+        minIntPolicy = MinIntPolicy()
+        intersect = tuple_intersection(policy=minIntPolicy) # no lg_k
+        intersect.update(sk1)
+        intersect.update(sk2)
+
+        # has_result() indicates the intersection has been used,
+        # although the result may be the empty set
+        self.assertTrue(intersect.has_result())
+
+        # as with unions, the result is a compact sketch
+        result = intersect.get_result()
+        self.assertTrue(isinstance(result, compact_tuple_sketch))
+
+        # we know the sets overlap by 1/4
+        self.assertLessEqual(result.get_lower_bound(1), n / 4)
+        self.assertGreaterEqual(result.get_upper_bound(1), n / 4)
+
+        # in this example, we intersected the sketches and took the
+        # min value as the resulting summary, so all summaries
+        # must be exactly equal to that value
+        count5 = 0
+        for pair in result:
+          if pair[1] == 5:
+            count5 += 1
+          else:
+            self.fail()
+        self.assertEqual(count5, result.get_num_retained())
+
+        # A NOT B
+        # create an a_not_b object
+        anb = tuple_a_not_b() # no lg_k or policy
+        result = anb.compute(sk1, sk2)
+
+        # as with unions, the result is a compact sketch
+        self.assertTrue(isinstance(result, compact_tuple_sketch))
+
+        # we know the sets overlap by 1/4, so the remainder is 3/4
+        self.assertLessEqual(result.get_lower_bound(1), 3 * n / 4)
+        self.assertGreaterEqual(result.get_upper_bound(1), 3 * n / 4)
+
+        # here, we have only values with a summary of 5 as any keys that
+        # existed in both sketches were removed
+        count5 = 0
+        for pair in result:
+          if pair[1] == 5:
+            count5 += 1
+          else:
+            self.fail()
+        self.assertEqual(count5, result.get_num_retained())
+
+        # JACCARD SIMILARITY
+        # Jaccard Similarity measure returns (lower_bound, estimate, upper_bound)
+        # and does not examine summaries, even for (dis)similarity tests.
+        jac = tuple_jaccard_similarity.jaccard(sk1, sk2)
+
+        # we can check that results are in the expected order
+        self.assertLess(jac[0], jac[1])
+        self.assertLess(jac[1], jac[2])
+
+        # checks for sketch equivalency
+        self.assertTrue(tuple_jaccard_similarity.exactly_equal(sk1, sk1))
+        self.assertFalse(tuple_jaccard_similarity.exactly_equal(sk1, sk2))
+
+        # we can apply a check for similarity or dissimilarity at a
+        # given threshhold, at 97.7% confidence.
+
+        # check that the Jaccard Index is at most (upper bound) 0.2.
+        # exact result would be 1/7
+        self.assertTrue(tuple_jaccard_similarity.dissimilarity_test(sk1, sk2, 0.2))
+
+        # check that the Jaccard Index is at least (lower bound) 0.7
+        # exact result would be 3/4, using result from A NOT B test
+        self.assertTrue(tuple_jaccard_similarity.similarity_test(sk1, result, 0.7))
+
+
+    # Generates a basic tuple sketch using a fixed integer summary of 2
+    def generate_tuple_sketch(self, n, k, summary, policy, offset=0):
+      sk = update_tuple_sketch(k, policy)
+      for i in range(0, n):
+        sk.update(i + offset, summary)
+      return sk
+        
+if __name__ == '__main__':
+    unittest.main()
+
+  

--- a/python/tests/tuple_test.py
+++ b/python/tests/tuple_test.py
@@ -32,7 +32,7 @@ class TupleTest(unittest.TestCase):
 
         # create a sketch and inject some values -- summary is 2 so we can sum them
         # and know the reuslt
-        sk = self.generate_tuple_sketch(n, k, summary=2, policy=AccumulatorPolicy())
+        sk = self.generate_tuple_sketch(AccumulatorPolicy(), n, k, summary=2)
 
         # we can check that the upper and lower bounds bracket the
         # estimate, without needing to know the exact value.
@@ -84,13 +84,12 @@ class TupleTest(unittest.TestCase):
         offset = int(3 * n / 4) # it's a float w/o cast
 
         # create a couple sketches and inject some values, with different summaries
-        sk1 = self.generate_tuple_sketch(n, k, summary=5, policy=AccumulatorPolicy())
-        sk2 = self.generate_tuple_sketch(n, k, summary=7, policy=AccumulatorPolicy(), offset=offset)
+        sk1 = self.generate_tuple_sketch(AccumulatorPolicy(), n, k, summary=5)
+        sk2 = self.generate_tuple_sketch(AccumulatorPolicy(), n, k, summary=7, offset=offset)
 
         # UNIONS
         # create a union object
-        maxIntPolicy = MaxIntPolicy()
-        union = tuple_union(k, policy=maxIntPolicy)
+        union = tuple_union(MaxIntPolicy(), k)
         union.update(sk1)
         union.update(sk2)
 
@@ -122,8 +121,7 @@ class TupleTest(unittest.TestCase):
 
         # INTERSECTIONS
         # create an intersection object
-        minIntPolicy = MinIntPolicy()
-        intersect = tuple_intersection(policy=minIntPolicy) # no lg_k
+        intersect = tuple_intersection(MinIntPolicy()) # no lg_k
         intersect.update(sk1)
         intersect.update(sk2)
 
@@ -198,8 +196,8 @@ class TupleTest(unittest.TestCase):
 
 
     # Generates a basic tuple sketch using a fixed integer summary of 2
-    def generate_tuple_sketch(self, n, k, summary, policy, offset=0):
-      sk = update_tuple_sketch(k, policy)
+    def generate_tuple_sketch(self, policy, n, k, summary, offset=0):
+      sk = update_tuple_sketch(policy, k)
       for i in range(0, n):
         sk.update(i + offset, summary)
       return sk

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
     url='http://datasketches.apache.org',
     long_description=open('python/README.md').read(),
     long_description_content_type='text/markdown',
-    packages=find_packages(where='python',exclude=['src','*tests*']), # src not needed if only the .so
+    packages=find_packages(where='python',exclude=['src','include','*tests*']), # src not needed if only the .so
     package_dir={'':'python'},
     # may need to add all source paths for sdist packages w/o MANIFEST.in
     ext_modules=[CMakeExtension('datasketches')],


### PR DESCRIPTION
This adds tuple sketch support to the python library, and specifically provides an arbitrary python object as the summary, as well as custom python policies for set operations.

A few basic policy implementations are included. They both demonstrate examples of how to implement a custom policy as well as provide a few basic options that seem reasonably useful.

And unlike the previous attempt, this has unit tests in place. And I hope somewhat improved documentation.