### PR TITLE
Remove unsigned < 0 check

### DIFF
--- a/cpc/include/cpc_compressor_impl.hpp
+++ b/cpc/include/cpc_compressor_impl.hpp
@@ -449,7 +449,7 @@ uint8_t cpc_compressor<A>::determine_pseudo_phase(uint8_t lg_k, uint32_t c) {
     if (lg_k < 4) throw std::logic_error("lgK < 4");
     const size_t tmp = c >> (lg_k - 4);
     const uint8_t phase = tmp & 15;
-    if (phase < 0 || phase >= 16) throw std::out_of_range("wrong phase");
+    if (phase >= 16) throw std::out_of_range("wrong phase");
     return phase;
   }
 }


### PR DESCRIPTION
uint8_t can never be < 0 so this addresses a warning from gcc.