### PR TITLE
Build linux arm64/aarch64 wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -3,10 +3,11 @@ name: Build Python Wheels
 on:
   # allow manual runs
   workflow_dispatch:
+  
   # run when we tag a release
-  release:
-    types:
-      - "created"
+  #release:
+  #  types:
+  #    - "created"
 
 env:
   BUILD_TYPE: Release
@@ -29,7 +30,7 @@ jobs:
       - name: Build sdist
         run: python -m build --sdist --outdir dist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
 
@@ -37,7 +38,6 @@ jobs:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
     strategy:
-      #fail-fast: false
       matrix:
         config:
         - {
@@ -56,6 +56,12 @@ jobs:
             cibw-arch: manylinux_x86_64
           }
         - {
+            name: "Ubuntu Latest (ARM64)",
+            os: ubuntu-latest,
+            cibw-arch: manylinux_aarch64,
+            use-qemu: true
+          }
+        - {
             name: "Ubuntu Latest (i686)",
             os: ubuntu-latest,
             cibw-arch: manylinux_i686
@@ -66,7 +72,6 @@ jobs:
             cibw-arch: win_amd64
           }
 
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -75,25 +80,27 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
-           
+
+      - name: Set up QEMU for linux/arm64 builds
+        if: runner.os == 'Linux' && matrix.config.use-qemu == true
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+
       - name: Install Python dependencies
-        run: python -m pip install cibuildwheel==2.5.0
-        
-      - name: Configure cibuildwheel
-        shell: bash
-        run: |
-          CMAKE_OSX_ARCHITECTURES=${{ matrix.config.cibw-arch == 'macosx_x86_64' && 'x86_64' || matrix.config.cibw-arch == 'macosx_arm64' && 'arm64' || matrix.config.cibw-arch == 'macosx_universal2' && '"arm64;x86_64"' || '' }}
-          echo "CIBW_ARCHS_MACOS=x86_64 arm64" >> $GITHUB_ENV
-          echo "CIBW_BUILD=*-${{ matrix.config.cibw-arch }}" >> $GITHUB_ENV
-          echo "CIBW_ENVIRONMENT_MACOS=CMAKE_OSX_ARCHITECTURES=\"$CMAKE_OSX_ARCHITECTURES\"" >> $GITHUB_ENV
-        
+        run: python -m pip install cibuildwheel==2.12.0
+
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist
         env:
+          CIBW_ARCHS_LINUX: "auto aarch64"
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_ENVIRONMENT_MACOS: CMAKE_OSX_ARCHITECTURES=${{ matrix.config.cibw-arch == 'macosx_x86_64' && 'x86_64' || matrix.config.cibw-arch == 'macosx_arm64' && 'arm64' || '' }}
+          CIBW_BUILD: "*-${{ matrix.config.cibw-arch }}"
           CIBW_BEFORE_BUILD_LINUX: "yum remove -y cmake"
           CIBW_BEFORE_BUILD: "python -m pip install cmake>=3.18"
-          CIBW_SKIP: "*-win32 pp*-macosx*"
+          CIBW_SKIP: "*-win32 pp*-aarch64 pp*-macosx"
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./dist/*.whl


### PR DESCRIPTION
QEMU seems to be the standard way to build wheels for arm64/aarch64 (same thing) with github actions. Cross compilation doesn't seem to be supported by cibuildwheel currently. The drawback of QEMU is that it's very, very slow.

Also removed a config step by putting the logic into a more appropriate step's env variables.

Tested a reduced set of platforms with a single python version and verified that the .so produced reports back as the right file type. I don't have an AWS instance to test this on, so waiting for the result of testing in  #333 .  If that works, this should be good to merge (and then maybe back-port into the 4.0.x branch).