### PR TITLE
Reduce likelihood of macro collision

### DIFF
--- a/common/include/MurmurHash3.h
+++ b/common/include/MurmurHash3.h
@@ -29,13 +29,13 @@ typedef unsigned char uint8_t;
 typedef unsigned int uint32_t;
 typedef unsigned __int64 uint64_t;
 
-#define FORCE_INLINE	__forceinline
+#define MURMUR3_FORCE_INLINE	__forceinline
 
 #include <stdlib.h>
 
 #define MURMUR3_ROTL64(x,y)	_rotl64(x,y)
 
-#define BIG_CONSTANT(x) (x)
+#define MURMUR3_BIG_CONSTANT(x) (x)
 
 // Other compilers
 
@@ -43,7 +43,7 @@ typedef unsigned __int64 uint64_t;
 
 #include <stdint.h>
 
-#define	FORCE_INLINE inline __attribute__((always_inline))
+#define	MURMUR3_FORCE_INLINE inline __attribute__((always_inline))
 
 inline uint64_t rotl64 ( uint64_t x, int8_t r )
 {
@@ -52,7 +52,7 @@ inline uint64_t rotl64 ( uint64_t x, int8_t r )
 
 #define MURMUR3_ROTL64(x,y)	rotl64(x,y)
 
-#define BIG_CONSTANT(x) (x##LLU)
+#define MURMUR3_BIG_CONSTANT(x) (x##LLU)
 
 #endif // !defined(_MSC_VER)
 
@@ -71,7 +71,7 @@ typedef struct {
 // Block read - if your platform needs to do endian-swapping or can only
 // handle aligned reads, do the conversion here
 
-FORCE_INLINE uint64_t getblock64 ( const uint64_t * p, size_t i )
+MURMUR3_FORCE_INLINE uint64_t getblock64 ( const uint64_t * p, size_t i )
 {
   uint64_t res;
   memcpy(&res, p + i, sizeof(res));
@@ -81,20 +81,21 @@ FORCE_INLINE uint64_t getblock64 ( const uint64_t * p, size_t i )
 //-----------------------------------------------------------------------------
 // Finalization mix - force all bits of a hash block to avalanche
 
-FORCE_INLINE uint64_t fmix64 ( uint64_t k )
+MURMUR3_FORCE_INLINE uint64_t fmix64 ( uint64_t k )
 {
   k ^= k >> 33;
-  k *= BIG_CONSTANT(0xff51afd7ed558ccd);
+  k *= MURMUR3_BIG_CONSTANT(0xff51afd7ed558ccd);
   k ^= k >> 33;
-  k *= BIG_CONSTANT(0xc4ceb9fe1a85ec53);
+  k *= MURMUR3_BIG_CONSTANT(0xc4ceb9fe1a85ec53);
   k ^= k >> 33;
 
   return k;
 }
 
-FORCE_INLINE void MurmurHash3_x64_128(const void* key, size_t lenBytes, uint64_t seed, HashState& out) {
-  static const uint64_t c1 = BIG_CONSTANT(0x87c37b91114253d5);
-  static const uint64_t c2 = BIG_CONSTANT(0x4cf5ad432745937f);
+MURMUR3_FORCE_INLINE void MurmurHash3_x64_128(const void* key, size_t lenBytes,
+                                              uint64_t seed, HashState& out) {
+  static const uint64_t c1 = MURMUR3_BIG_CONSTANT(0x87c37b91114253d5);
+  static const uint64_t c2 = MURMUR3_BIG_CONSTANT(0x4cf5ad432745937f);
 
   const uint8_t* data = (const uint8_t*)key;
 
@@ -168,10 +169,14 @@ FORCE_INLINE void MurmurHash3_x64_128(const void* key, size_t lenBytes, uint64_t
 
 //-----------------------------------------------------------------------------
 
-FORCE_INLINE uint16_t compute_seed_hash(uint64_t seed) {
+MURMUR3_FORCE_INLINE uint16_t compute_seed_hash(uint64_t seed) {
   HashState hashes;
   MurmurHash3_x64_128(&seed, sizeof(seed), 0, hashes);
   return static_cast<uint16_t>(hashes.h1 & 0xffff);
 }
+
+#undef MURMUR3_FORCE_INLINE
+#undef MURMUR3_ROTL64
+#undef MURMUR3_BIG_CONSTANT
 
 #endif // _MURMURHASH3_H_

--- a/common/include/MurmurHash3.h
+++ b/common/include/MurmurHash3.h
@@ -33,8 +33,7 @@ typedef unsigned __int64 uint64_t;
 
 #include <stdlib.h>
 
-#define ROTL32(x,y)	_rotl(x,y)
-#define ROTL64(x,y)	_rotl64(x,y)
+#define MURMUR3_ROTL64(x,y)	_rotl64(x,y)
 
 #define BIG_CONSTANT(x) (x)
 
@@ -46,18 +45,12 @@ typedef unsigned __int64 uint64_t;
 
 #define	FORCE_INLINE inline __attribute__((always_inline))
 
-inline uint32_t rotl32 ( uint32_t x, int8_t r )
-{
-  return (x << r) | (x >> (32 - r));
-}
-
 inline uint64_t rotl64 ( uint64_t x, int8_t r )
 {
   return (x << r) | (x >> (64 - r));
 }
 
-#define	ROTL32(x,y)	rotl32(x,y)
-#define ROTL64(x,y)	rotl64(x,y)
+#define MURMUR3_ROTL64(x,y)	rotl64(x,y)
 
 #define BIG_CONSTANT(x) (x##LLU)
 
@@ -118,13 +111,13 @@ FORCE_INLINE void MurmurHash3_x64_128(const void* key, size_t lenBytes, uint64_t
     uint64_t k1 = getblock64(blocks, i * 2 + 0);
     uint64_t k2 = getblock64(blocks, i * 2 + 1);
 
-    k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; out.h1 ^= k1;
-    out.h1 = ROTL64(out.h1,27);
+    k1 *= c1; k1  = MURMUR3_ROTL64(k1,31); k1 *= c2; out.h1 ^= k1;
+    out.h1 = MURMUR3_ROTL64(out.h1,27);
     out.h1 += out.h2;
     out.h1 = out.h1*5+0x52dce729;
 
-    k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; out.h2 ^= k2;
-    out.h2 = ROTL64(out.h2,31);
+    k2 *= c2; k2  = MURMUR3_ROTL64(k2,33); k2 *= c1; out.h2 ^= k2;
+    out.h2 = MURMUR3_ROTL64(out.h2,31);
     out.h2 += out.h1;
     out.h2 = out.h2*5+0x38495ab5;
   }
@@ -144,7 +137,7 @@ FORCE_INLINE void MurmurHash3_x64_128(const void* key, size_t lenBytes, uint64_t
   case 11: k2 ^= ((uint64_t)tail[10]) << 16; // falls through
   case 10: k2 ^= ((uint64_t)tail[ 9]) << 8;  // falls through
   case  9: k2 ^= ((uint64_t)tail[ 8]) << 0;
-           k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; out.h2 ^= k2;
+           k2 *= c2; k2  = MURMUR3_ROTL64(k2,33); k2 *= c1; out.h2 ^= k2;
            // falls through
   case  8: k1 ^= ((uint64_t)tail[ 7]) << 56; // falls through
   case  7: k1 ^= ((uint64_t)tail[ 6]) << 48; // falls through
@@ -154,7 +147,7 @@ FORCE_INLINE void MurmurHash3_x64_128(const void* key, size_t lenBytes, uint64_t
   case  3: k1 ^= ((uint64_t)tail[ 2]) << 16; // falls through
   case  2: k1 ^= ((uint64_t)tail[ 1]) << 8; // falls through
   case  1: k1 ^= ((uint64_t)tail[ 0]) << 0;
-           k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; out.h1 ^= k1;
+           k1 *= c1; k1  = MURMUR3_ROTL64(k1,31); k1 *= c2; out.h1 ^= k1;
   };
 
   //----------

--- a/cpc/include/cpc_util.hpp
+++ b/cpc/include/cpc_util.hpp
@@ -89,7 +89,13 @@ static inline uint32_t warren_count_bits_set_in_matrix(const uint64_t* array, ui
 
 // This code is Figure 5-9 in "Hacker's Delight" by Henry S. Warren.
 
-#define CSA(h,l,a,b,c) {uint64_t u = a ^ b; uint64_t v = c; h = (a & b) | (u & v); l = u ^ v;}
+#define DATASKETCHES_CSA(h, l, a, b, c) \
+  {                                     \
+    uint64_t u = a ^ b;                 \
+    uint64_t v = c;                     \
+    h = (a & b) | (u & v);              \
+    l = u ^ v;                          \
+  }
 
 static inline uint32_t count_bits_set_in_matrix(const uint64_t* a, uint32_t length) {
   if ((length & 0x7) != 0) throw std::invalid_argument("the length of the array must be a multiple of 8");
@@ -98,15 +104,15 @@ static inline uint32_t count_bits_set_in_matrix(const uint64_t* a, uint32_t leng
   fours = twos = ones = 0;
 
   for (uint32_t i = 0; i <= length - 8; i += 8) {
-    CSA(twos_a, ones, ones, a[i+0], a[i+1]);
-    CSA(twos_b, ones, ones, a[i+2], a[i+3]);
-    CSA(fours_a, twos, twos, twos_a, twos_b);
+    DATASKETCHES_CSA(twos_a, ones, ones, a[i+0], a[i+1]);
+    DATASKETCHES_CSA(twos_b, ones, ones, a[i+2], a[i+3]);
+    DATASKETCHES_CSA(fours_a, twos, twos, twos_a, twos_b);
 
-    CSA(twos_a, ones, ones, a[i+4], a[i+5]);
-    CSA(twos_b, ones, ones, a[i+6], a[i+7]);
-    CSA(fours_b, twos, twos, twos_a, twos_b);
+    DATASKETCHES_CSA(twos_a, ones, ones, a[i+4], a[i+5]);
+    DATASKETCHES_CSA(twos_b, ones, ones, a[i+6], a[i+7]);
+    DATASKETCHES_CSA(fours_b, twos, twos, twos_a, twos_b);
 
-    CSA(eights, fours, fours, fours_a, fours_b);
+    DATASKETCHES_CSA(eights, fours, fours, fours_a, fours_b);
 
     total += warren_bit_count(eights);
   }
@@ -118,6 +124,8 @@ static inline uint32_t count_bits_set_in_matrix(const uint64_t* a, uint32_t leng
 
   return total;
 }
+
+#undef DATASKETCHES_CSA
 
 // Here are some timings made with quickTestMerge.c
 // for the "5 5" case:


### PR DESCRIPTION
. . . by removing one macro and prefacing the other with the logical module it's associated with.