### PR TITLE
ensure we use std::abs() everywhere

### DIFF
--- a/kll/test/kll_sketch_test.cpp
+++ b/kll/test/kll_sketch_test.cpp
@@ -242,7 +242,7 @@ TEST_CASE("kll sketch", "[kll_sketch]") {
           FAIL("checking rank vs CDF for value " + std::to_string(i));
         }
         subtotal_pmf += pmf[i];
-        if (abs(ranks[i] - subtotal_pmf) > NUMERIC_NOISE_TOLERANCE) {
+        if (std::abs(ranks[i] - subtotal_pmf) > NUMERIC_NOISE_TOLERANCE) {
           FAIL("CDF vs PMF for value " + std::to_string(i));
         }
       }
@@ -257,7 +257,7 @@ TEST_CASE("kll sketch", "[kll_sketch]") {
           FAIL("checking rank vs CDF for value " + std::to_string(i));
         }
         subtotal_pmf += pmf[i];
-        if (abs(ranks[i] - subtotal_pmf) > NUMERIC_NOISE_TOLERANCE) {
+        if (std::abs(ranks[i] - subtotal_pmf) > NUMERIC_NOISE_TOLERANCE) {
           FAIL("CDF vs PMF for value " + std::to_string(i));
         }
       }

--- a/quantiles/test/quantiles_sketch_test.cpp
+++ b/quantiles/test/quantiles_sketch_test.cpp
@@ -260,7 +260,7 @@ TEST_CASE("quantiles sketch", "[quantiles_sketch]") {
         REQUIRE(sketch.get_rank(values[i]) == ranks[i]);
       }
       subtotal_pmf += pmf[i];
-      if (abs(ranks[i] - subtotal_pmf) > NUMERIC_NOISE_TOLERANCE) {
+      if (std::abs(ranks[i] - subtotal_pmf) > NUMERIC_NOISE_TOLERANCE) {
         std::cerr << "CDF vs PMF for value " << i << std::endl;
         REQUIRE(ranks[i] == Approx(subtotal_pmf).margin(NUMERIC_NOISE_TOLERANCE));
       }

--- a/sampling/include/var_opt_union_impl.hpp
+++ b/sampling/include/var_opt_union_impl.hpp
@@ -543,7 +543,7 @@ void var_opt_union<T, A>::mark_moving_gadget_coercer(var_opt_sketch<T, A>& sk) c
   }
 
   if (result_h + result_r != result_k) throw std::logic_error("H + R counts must equal k");
-  if (fabs(transferred_weight - outer_tau_numer_) > 1e-10) {
+  if (std::abs(transferred_weight - outer_tau_numer_) > 1e-10) {
     throw std::logic_error("uexpected mismatch in transferred weight");
   }
 


### PR DESCRIPTION
Was playing with compiler warning flags and it pointed out that we were calling the integer abs() on float values, so I decided to ensure we're using std::abs() globally, even where we had fabs() before.