### PR TITLE
Remove inheritance from std::iterator

### DIFF
--- a/fi/include/reverse_purge_hash_map.hpp
+++ b/fi/include/reverse_purge_hash_map.hpp
@@ -91,8 +91,14 @@ private:
 
 // This iterator uses strides based on golden ratio to avoid clustering during merge
 template<typename K, typename V, typename H, typename E, typename A>
-class reverse_purge_hash_map<K, V, H, E, A>::iterator: public std::iterator<std::input_iterator_tag, K> {
+class reverse_purge_hash_map<K, V, H, E, A>::iterator {
 public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type = std::pair<K&, V>;
+  using difference_type = std::ptrdiff_t;
+  using pointer = void;
+  using reference = value_type&;
+
   friend class reverse_purge_hash_map<K, V, H, E, A>;
   iterator& operator++() {
     ++count;
@@ -107,8 +113,8 @@ public:
   iterator operator++(int) { iterator tmp(*this); operator++(); return tmp; }
   bool operator==(const iterator& rhs) const { return count == rhs.count; }
   bool operator!=(const iterator& rhs) const { return count != rhs.count; }
-  const std::pair<K&, V> operator*() const {
-    return std::pair<K&, V>(map->keys_[index], map->values_[index]);
+  const value_type operator*() const {
+    return value_type(map->keys_[index], map->values_[index]);
   }
 private:
   static constexpr double GOLDEN_RATIO_RECIPROCAL = 0.6180339887498949; // = (sqrt(5) - 1) / 2

--- a/fi/include/reverse_purge_hash_map.hpp
+++ b/fi/include/reverse_purge_hash_map.hpp
@@ -97,7 +97,7 @@ public:
   using value_type = std::pair<K&, V>;
   using difference_type = void;
   using pointer = void;
-  using reference = value_type;
+  using reference = const value_type;
 
   friend class reverse_purge_hash_map<K, V, H, E, A>;
   iterator& operator++() {
@@ -113,7 +113,7 @@ public:
   iterator operator++(int) { iterator tmp(*this); operator++(); return tmp; }
   bool operator==(const iterator& rhs) const { return count == rhs.count; }
   bool operator!=(const iterator& rhs) const { return count != rhs.count; }
-  const reference operator*() const {
+  reference operator*() const {
     return value_type(map->keys_[index], map->values_[index]);
   }
 private:

--- a/fi/include/reverse_purge_hash_map.hpp
+++ b/fi/include/reverse_purge_hash_map.hpp
@@ -95,9 +95,9 @@ class reverse_purge_hash_map<K, V, H, E, A>::iterator {
 public:
   using iterator_category = std::input_iterator_tag;
   using value_type = std::pair<K&, V>;
-  using difference_type = std::ptrdiff_t;
+  using difference_type = void;
   using pointer = void;
-  using reference = value_type&;
+  using reference = value_type;
 
   friend class reverse_purge_hash_map<K, V, H, E, A>;
   iterator& operator++() {
@@ -113,7 +113,7 @@ public:
   iterator operator++(int) { iterator tmp(*this); operator++(); return tmp; }
   bool operator==(const iterator& rhs) const { return count == rhs.count; }
   bool operator!=(const iterator& rhs) const { return count != rhs.count; }
-  const value_type operator*() const {
+  const reference operator*() const {
     return value_type(map->keys_[index], map->values_[index]);
   }
 private:

--- a/hll/include/HllArray-internal.hpp
+++ b/hll/include/HllArray-internal.hpp
@@ -636,7 +636,7 @@ bool HllArray<A>::const_iterator::operator!=(const const_iterator& other) const 
 }
 
 template<typename A>
-uint32_t HllArray<A>::const_iterator::operator*() const {
+auto HllArray<A>::const_iterator::operator*() const -> reference {
   return HllUtil<A>::pair(index_, value_);
 }
 

--- a/hll/include/HllArray.hpp
+++ b/hll/include/HllArray.hpp
@@ -117,7 +117,7 @@ class HllArray<A>::const_iterator {
 public:
   using iterator_category = std::input_iterator_tag;
   using value_type = uint32_t;
-  using difference_type = int32_t;
+  using difference_type = void;
   using pointer = uint32_t*;
   using reference = uint32_t;
 

--- a/hll/include/HllArray.hpp
+++ b/hll/include/HllArray.hpp
@@ -119,12 +119,12 @@ public:
   using value_type = uint32_t;
   using difference_type = int32_t;
   using pointer = uint32_t*;
-  using reference = uint32_t&;
+  using reference = uint32_t;
 
   const_iterator(const uint8_t* array, uint32_t array_slze, uint32_t index, target_hll_type hll_type, const AuxHashMap<A>* exceptions, uint8_t offset, bool all);
   const_iterator& operator++();
   bool operator!=(const const_iterator& other) const;
-  uint32_t operator*() const;
+  reference operator*() const;
 private:
   const uint8_t* array_;
   uint32_t array_size_;

--- a/hll/include/HllArray.hpp
+++ b/hll/include/HllArray.hpp
@@ -113,8 +113,14 @@ class HllArray : public HllSketchImpl<A> {
 };
 
 template<typename A>
-class HllArray<A>::const_iterator: public std::iterator<std::input_iterator_tag, uint32_t> {
+class HllArray<A>::const_iterator {
 public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type = uint32_t;
+  using difference_type = int32_t;
+  using pointer = uint32_t*;
+  using reference = uint32_t&;
+
   const_iterator(const uint8_t* array, uint32_t array_slze, uint32_t index, target_hll_type hll_type, const AuxHashMap<A>* exceptions, uint8_t offset, bool all);
   const_iterator& operator++();
   bool operator!=(const const_iterator& other) const;

--- a/hll/include/coupon_iterator-internal.hpp
+++ b/hll/include/coupon_iterator-internal.hpp
@@ -47,7 +47,7 @@ bool coupon_iterator<A>::operator!=(const coupon_iterator& other) const {
 }
 
 template<typename A>
-uint32_t coupon_iterator<A>::operator*() const {
+auto coupon_iterator<A>::operator*() const -> reference {
   return array_[index_];
 }
 

--- a/hll/include/coupon_iterator.hpp
+++ b/hll/include/coupon_iterator.hpp
@@ -23,8 +23,14 @@
 namespace datasketches {
 
 template<typename A>
-class coupon_iterator: public std::iterator<std::input_iterator_tag, uint32_t> {
+class coupon_iterator {
 public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type = uint32_t;
+  using difference_type = int32_t;
+  using pointer = uint32_t*;
+  using reference = uint32_t&;
+
   coupon_iterator(const uint32_t* array, size_t array_slze, size_t index, bool all);
   coupon_iterator& operator++();
   bool operator!=(const coupon_iterator& other) const;

--- a/hll/include/coupon_iterator.hpp
+++ b/hll/include/coupon_iterator.hpp
@@ -27,7 +27,7 @@ class coupon_iterator {
 public:
   using iterator_category = std::input_iterator_tag;
   using value_type = uint32_t;
-  using difference_type = int32_t;
+  using difference_type = void;
   using pointer = uint32_t*;
   using reference = uint32_t;
 

--- a/hll/include/coupon_iterator.hpp
+++ b/hll/include/coupon_iterator.hpp
@@ -29,12 +29,12 @@ public:
   using value_type = uint32_t;
   using difference_type = int32_t;
   using pointer = uint32_t*;
-  using reference = uint32_t&;
+  using reference = uint32_t;
 
   coupon_iterator(const uint32_t* array, size_t array_slze, size_t index, bool all);
   coupon_iterator& operator++();
   bool operator!=(const coupon_iterator& other) const;
-  uint32_t operator*() const;
+  reference operator*() const;
 private:
   const uint32_t* array_;
   size_t array_size_;

--- a/kll/include/kll_sketch.hpp
+++ b/kll/include/kll_sketch.hpp
@@ -591,16 +591,16 @@ public:
   using iterator_category = std::input_iterator_tag;
   using value_type = std::pair<const T&, const uint64_t>;
   using difference_type = std::ptrdiff_t;
-  using pointer = return_value_holder<value_type>;
-  using reference = value_type&;
+  using pointer = const return_value_holder<value_type>;
+  using reference = const value_type;
 
   friend class kll_sketch<T, C, A>;
   const_iterator& operator++();
   const_iterator& operator++(int);
   bool operator==(const const_iterator& other) const;
   bool operator!=(const const_iterator& other) const;
-  const value_type operator*() const;
-  const return_value_holder<value_type> operator->() const;
+  reference operator*() const;
+  pointer operator->() const;
 private:
   const T* items;
   const uint32_t* levels;

--- a/kll/include/kll_sketch.hpp
+++ b/kll/include/kll_sketch.hpp
@@ -590,7 +590,7 @@ class kll_sketch<T, C, A>::const_iterator {
 public:
   using iterator_category = std::input_iterator_tag;
   using value_type = std::pair<const T&, const uint64_t>;
-  using difference_type = std::ptrdiff_t;
+  using difference_type = void;
   using pointer = const return_value_holder<value_type>;
   using reference = const value_type;
 

--- a/kll/include/kll_sketch.hpp
+++ b/kll/include/kll_sketch.hpp
@@ -586,9 +586,14 @@ class kll_sketch {
 };
 
 template<typename T, typename C, typename A>
-class kll_sketch<T, C, A>::const_iterator: public std::iterator<std::input_iterator_tag, T> {
+class kll_sketch<T, C, A>::const_iterator {
 public:
+  using iterator_category = std::input_iterator_tag;
   using value_type = std::pair<const T&, const uint64_t>;
+  using difference_type = std::ptrdiff_t;
+  using pointer = return_value_holder<value_type>;
+  using reference = value_type&;
+
   friend class kll_sketch<T, C, A>;
   const_iterator& operator++();
   const_iterator& operator++(int);

--- a/kll/include/kll_sketch_impl.hpp
+++ b/kll/include/kll_sketch_impl.hpp
@@ -1105,12 +1105,12 @@ bool kll_sketch<T, C, A>::const_iterator::operator!=(const const_iterator& other
 }
 
 template<typename T, typename C, typename A>
-auto kll_sketch<T, C, A>::const_iterator::operator*() const -> const value_type {
+auto kll_sketch<T, C, A>::const_iterator::operator*() const -> reference {
   return value_type(items[index], weight);
 }
 
 template<typename T, typename C, typename A>
-auto kll_sketch<T, C, A>::const_iterator::operator->() const -> const return_value_holder<value_type> {
+auto kll_sketch<T, C, A>::const_iterator::operator->() const -> pointer {
   return **this;
 }
 

--- a/quantiles/include/quantiles_sketch.hpp
+++ b/quantiles/include/quantiles_sketch.hpp
@@ -580,9 +580,14 @@ private:
 
 
 template<typename T, typename C, typename A>
-class quantiles_sketch<T, C, A>::const_iterator: public std::iterator<std::input_iterator_tag, T> {
+class quantiles_sketch<T, C, A>::const_iterator {
 public:
+  using iterator_category = std::input_iterator_tag;
   using value_type = std::pair<const T&, const uint64_t>;
+  using difference_type = std::ptrdiff_t;
+  using pointer = return_value_holder<value_type>;
+  using reference = value_type&;
+
   const_iterator& operator++();
   const_iterator& operator++(int);
   bool operator==(const const_iterator& other) const;

--- a/quantiles/include/quantiles_sketch.hpp
+++ b/quantiles/include/quantiles_sketch.hpp
@@ -584,7 +584,7 @@ class quantiles_sketch<T, C, A>::const_iterator {
 public:
   using iterator_category = std::input_iterator_tag;
   using value_type = std::pair<const T&, const uint64_t>;
-  using difference_type = std::ptrdiff_t;
+  using difference_type = void;
   using pointer = const return_value_holder<value_type>;
   using reference = const value_type;
 

--- a/quantiles/include/quantiles_sketch.hpp
+++ b/quantiles/include/quantiles_sketch.hpp
@@ -585,15 +585,15 @@ public:
   using iterator_category = std::input_iterator_tag;
   using value_type = std::pair<const T&, const uint64_t>;
   using difference_type = std::ptrdiff_t;
-  using pointer = return_value_holder<value_type>;
-  using reference = value_type&;
+  using pointer = const return_value_holder<value_type>;
+  using reference = const value_type;
 
   const_iterator& operator++();
   const_iterator& operator++(int);
   bool operator==(const const_iterator& other) const;
   bool operator!=(const const_iterator& other) const;
-  const value_type operator*() const;
-  const return_value_holder<value_type> operator->() const;
+  reference operator*() const;
+  pointer operator->() const;
 private:
   friend class quantiles_sketch<T, C, A>;
   using Level = std::vector<T, A>;

--- a/quantiles/include/quantiles_sketch_impl.hpp
+++ b/quantiles/include/quantiles_sketch_impl.hpp
@@ -1354,12 +1354,12 @@ bool quantiles_sketch<T, C, A>::const_iterator::operator!=(const const_iterator&
 }
 
 template<typename T, typename C, typename A>
-auto quantiles_sketch<T, C, A>::const_iterator::operator*() const -> const value_type {
+auto quantiles_sketch<T, C, A>::const_iterator::operator*() const -> reference {
   return value_type(level_ == -1 ? base_buffer_[index_] : levels_[level_][index_], weight_);
 }
 
 template<typename T, typename C, typename A>
-auto quantiles_sketch<T, C, A>::const_iterator::operator->() const -> const return_value_holder<value_type> {
+auto quantiles_sketch<T, C, A>::const_iterator::operator->() const -> pointer {
   return **this;
 }
 

--- a/req/include/req_sketch.hpp
+++ b/req/include/req_sketch.hpp
@@ -404,15 +404,15 @@ public:
   using iterator_category = std::input_iterator_tag;
   using value_type = std::pair<const T&, const uint64_t>;
   using difference_type = std::ptrdiff_t;
-  using pointer = return_value_holder<value_type>;
-  using reference = value_type&;
+  using pointer = const return_value_holder<value_type>;
+  using reference = const value_type;
 
   const_iterator& operator++();
   const_iterator& operator++(int);
   bool operator==(const const_iterator& other) const;
   bool operator!=(const const_iterator& other) const;
-  const value_type operator*() const;
-  const return_value_holder<value_type> operator->() const;
+  reference operator*() const;
+  pointer operator->() const;
 private:
   using LevelsIterator = typename std::vector<Compactor, AllocCompactor>::const_iterator;
   LevelsIterator levels_it_;

--- a/req/include/req_sketch.hpp
+++ b/req/include/req_sketch.hpp
@@ -403,7 +403,7 @@ class req_sketch<T, C, A>::const_iterator {
 public:
   using iterator_category = std::input_iterator_tag;
   using value_type = std::pair<const T&, const uint64_t>;
-  using difference_type = std::ptrdiff_t;
+  using difference_type = void;
   using pointer = const return_value_holder<value_type>;
   using reference = const value_type;
 

--- a/req/include/req_sketch.hpp
+++ b/req/include/req_sketch.hpp
@@ -399,9 +399,14 @@ private:
 };
 
 template<typename T, typename C, typename A>
-class req_sketch<T, C, A>::const_iterator: public std::iterator<std::input_iterator_tag, T> {
+class req_sketch<T, C, A>::const_iterator {
 public:
+  using iterator_category = std::input_iterator_tag;
   using value_type = std::pair<const T&, const uint64_t>;
+  using difference_type = std::ptrdiff_t;
+  using pointer = return_value_holder<value_type>;
+  using reference = value_type&;
+
   const_iterator& operator++();
   const_iterator& operator++(int);
   bool operator==(const const_iterator& other) const;

--- a/req/include/req_sketch_impl.hpp
+++ b/req/include/req_sketch_impl.hpp
@@ -848,12 +848,12 @@ bool req_sketch<T, C, A>::const_iterator::operator!=(const const_iterator& other
 }
 
 template<typename T, typename C, typename A>
-auto req_sketch<T, C, A>::const_iterator::operator*() const -> const value_type {
+auto req_sketch<T, C, A>::const_iterator::operator*() const -> reference {
   return value_type(*compactor_it_, 1ULL << (*levels_it_).get_lg_weight());
 }
 
 template<typename T, typename C, typename A>
-auto req_sketch<T, C, A>::const_iterator::operator->() const -> const return_value_holder<value_type> {
+auto req_sketch<T, C, A>::const_iterator::operator->() const -> pointer {
   return **this;
 }
 

--- a/sampling/include/var_opt_sketch.hpp
+++ b/sampling/include/var_opt_sketch.hpp
@@ -346,9 +346,13 @@ class var_opt_sketch {
 };
 
 template<typename T, typename A>
-class var_opt_sketch<T, A>::const_iterator : public std::iterator<std::input_iterator_tag, T> {
-public:
+class var_opt_sketch<T, A>::const_iterator {
+  using iterator_category = std::input_iterator_tag;
   using value_type = std::pair<const T&, const double>;
+  using difference_type = std::ptrdiff_t;
+  using pointer = return_value_holder<value_type>;
+  using reference = value_type&;
+public:
   const_iterator(const const_iterator& other);
   const_iterator& operator++();
   const_iterator& operator++(int);
@@ -379,14 +383,20 @@ private:
 
 // non-const iterator for internal use
 template<typename T, typename A>
-class var_opt_sketch<T, A>::iterator : public std::iterator<std::input_iterator_tag, T> {
+class var_opt_sketch<T, A>::iterator {
 public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type = std::pair<T&, double>;
+  using difference_type = std::ptrdiff_t;
+  using pointer = return_value_holder<value_type>;
+  using reference = value_type&;
+
   iterator(const iterator& other);
   iterator& operator++();
   iterator& operator++(int);
   bool operator==(const iterator& other) const;
   bool operator!=(const iterator& other) const;
-  std::pair<T&, double> operator*();
+  value_type operator*();
 
 private:
   friend class var_opt_sketch<T, A>;

--- a/sampling/include/var_opt_sketch.hpp
+++ b/sampling/include/var_opt_sketch.hpp
@@ -350,7 +350,7 @@ class var_opt_sketch<T, A>::const_iterator {
 public:
   using iterator_category = std::input_iterator_tag;
   using value_type = std::pair<const T&, const double>;
-  using difference_type = std::ptrdiff_t;
+  using difference_type = void;
   using pointer = const return_value_holder<value_type>;
   using reference = const value_type;
 
@@ -388,9 +388,9 @@ class var_opt_sketch<T, A>::iterator {
 public:
   using iterator_category = std::input_iterator_tag;
   using value_type = std::pair<T&, double>;
-  using difference_type = std::ptrdiff_t;
+  using difference_type = void;
   using pointer = return_value_holder<value_type>;
-  using reference = value_type&;
+  using reference = value_type;
 
   iterator(const iterator& other);
   iterator& operator++();

--- a/sampling/include/var_opt_sketch.hpp
+++ b/sampling/include/var_opt_sketch.hpp
@@ -347,19 +347,20 @@ class var_opt_sketch {
 
 template<typename T, typename A>
 class var_opt_sketch<T, A>::const_iterator {
+public:
   using iterator_category = std::input_iterator_tag;
   using value_type = std::pair<const T&, const double>;
   using difference_type = std::ptrdiff_t;
-  using pointer = return_value_holder<value_type>;
-  using reference = value_type&;
-public:
+  using pointer = const return_value_holder<value_type>;
+  using reference = const value_type;
+
   const_iterator(const const_iterator& other);
   const_iterator& operator++();
   const_iterator& operator++(int);
   bool operator==(const const_iterator& other) const;
   bool operator!=(const const_iterator& other) const;
-  const value_type operator*() const;
-  const return_value_holder<value_type> operator->() const;
+  reference operator*() const;
+  pointer operator->() const;
 
 private:
   friend class var_opt_sketch<T, A>;

--- a/sampling/include/var_opt_sketch.hpp
+++ b/sampling/include/var_opt_sketch.hpp
@@ -369,8 +369,8 @@ private:
   // default iterator over full sketch
   const_iterator(const var_opt_sketch<T, A>& sk, bool is_end);
   
-  // iterates over only one of the H or R region, optionally applying weight correction
-  // to R region (can correct for numerical precision issues)
+  // iterates over only one of the H or R regions
+  // does not apply weight correction
   const_iterator(const var_opt_sketch<T, A>& sk, bool is_end, bool use_r_region);
 
   bool get_mark() const;
@@ -398,6 +398,7 @@ public:
   bool operator==(const iterator& other) const;
   bool operator!=(const iterator& other) const;
   reference operator*();
+  pointer operator->();
 
 private:
   friend class var_opt_sketch<T, A>;

--- a/sampling/include/var_opt_sketch.hpp
+++ b/sampling/include/var_opt_sketch.hpp
@@ -397,7 +397,7 @@ public:
   iterator& operator++(int);
   bool operator==(const iterator& other) const;
   bool operator!=(const iterator& other) const;
-  value_type operator*();
+  reference operator*();
 
 private:
   friend class var_opt_sketch<T, A>;

--- a/sampling/include/var_opt_sketch_impl.hpp
+++ b/sampling/include/var_opt_sketch_impl.hpp
@@ -1531,7 +1531,6 @@ var_opt_sketch<T, A>::const_iterator::const_iterator(const var_opt_sketch& sk, b
   if (idx_ == final_idx_) { sk_ = nullptr; }
 }
 
-
 template<typename T, typename A>
 var_opt_sketch<T, A>::const_iterator::const_iterator(const const_iterator& other) :
   sk_(other.sk_),
@@ -1543,6 +1542,9 @@ var_opt_sketch<T, A>::const_iterator::const_iterator(const const_iterator& other
 
 template<typename T, typename A>
 typename var_opt_sketch<T, A>::const_iterator& var_opt_sketch<T, A>::const_iterator::operator++() {
+  // accumulate weight already visited
+  if (idx_ > sk_->h_) { cum_r_weight_ += r_item_wt_; }
+
   ++idx_;
   
   if (idx_ == final_idx_) {
@@ -1551,7 +1553,6 @@ typename var_opt_sketch<T, A>::const_iterator& var_opt_sketch<T, A>::const_itera
   } else if (idx_ == sk_->h_ && sk_->r_ > 0) { // check for the gap
     ++idx_;
   }
-  if (idx_ > sk_->h_) { cum_r_weight_ += r_item_wt_; }
   return *this;
 }
 
@@ -1579,6 +1580,8 @@ auto var_opt_sketch<T, A>::const_iterator::operator*() const -> reference {
   double wt;
   if (idx_ < sk_->h_) {
     wt = sk_->weights_[idx_];
+  } else if (idx_ == final_idx_ - 1) {
+    wt = sk_->total_wt_r_ - cum_r_weight_;
   } else {
     wt = r_item_wt_;
   }
@@ -1627,6 +1630,9 @@ var_opt_sketch<T, A>::iterator::iterator(const iterator& other) :
 
 template<typename T, typename A>
 typename var_opt_sketch<T, A>::iterator& var_opt_sketch<T, A>::iterator::operator++() {
+  // accumulate weight already visited
+  if (idx_ > sk_->h_) { cum_r_weight_ += r_item_wt_; }
+
   ++idx_;
   
   if (idx_ == final_idx_) {
@@ -1635,7 +1641,7 @@ typename var_opt_sketch<T, A>::iterator& var_opt_sketch<T, A>::iterator::operato
   } else if (idx_ == sk_->h_ && sk_->r_ > 0) { // check for the gap
     ++idx_;
   }
-  if (idx_ > sk_->h_) { cum_r_weight_ += r_item_wt_; }
+
   return *this;
 }
 
@@ -1668,7 +1674,12 @@ auto var_opt_sketch<T, A>::iterator::operator*() -> reference {
   } else {
     wt = r_item_wt_;
   }
-  return std::pair<T&, double>(sk_->data_[idx_], wt);
+  return value_type(sk_->data_[idx_], wt);
+}
+
+template<typename T, typename A>
+auto var_opt_sketch<T, A>::iterator::operator->() -> pointer {
+  return **this;
 }
 
 template<typename T, typename A>

--- a/sampling/include/var_opt_sketch_impl.hpp
+++ b/sampling/include/var_opt_sketch_impl.hpp
@@ -1580,8 +1580,6 @@ auto var_opt_sketch<T, A>::const_iterator::operator*() const -> reference {
   double wt;
   if (idx_ < sk_->h_) {
     wt = sk_->weights_[idx_];
-  } else if (idx_ == final_idx_ - 1) {
-    wt = sk_->total_wt_r_ - cum_r_weight_;
   } else {
     wt = r_item_wt_;
   }

--- a/sampling/include/var_opt_sketch_impl.hpp
+++ b/sampling/include/var_opt_sketch_impl.hpp
@@ -1659,7 +1659,7 @@ bool var_opt_sketch<T, A>::iterator::operator!=(const iterator& other) const {
 }
 
 template<typename T, typename A>
-std::pair<T&, double> var_opt_sketch<T, A>::iterator::operator*() {
+auto var_opt_sketch<T, A>::iterator::operator*() -> reference {
   double wt;
   if (idx_ < sk_->h_) {
     wt = sk_->weights_[idx_];

--- a/sampling/include/var_opt_sketch_impl.hpp
+++ b/sampling/include/var_opt_sketch_impl.hpp
@@ -1575,7 +1575,7 @@ bool var_opt_sketch<T, A>::const_iterator::operator!=(const const_iterator& othe
 }
 
 template<typename T, typename A>
-auto var_opt_sketch<T, A>::const_iterator::operator*() const -> const value_type {
+auto var_opt_sketch<T, A>::const_iterator::operator*() const -> reference {
   double wt;
   if (idx_ < sk_->h_) {
     wt = sk_->weights_[idx_];
@@ -1586,7 +1586,7 @@ auto var_opt_sketch<T, A>::const_iterator::operator*() const -> const value_type
 }
 
 template<typename T, typename A>
-auto var_opt_sketch<T, A>::const_iterator::operator->() const -> const return_value_holder<value_type> {
+auto var_opt_sketch<T, A>::const_iterator::operator->() const -> pointer {
   return **this;
 }
 

--- a/theta/include/theta_update_sketch_base.hpp
+++ b/theta/include/theta_update_sketch_base.hpp
@@ -212,15 +212,15 @@ public:
   using iterator_category = std::input_iterator_tag;
   using value_type = const Entry;
   using difference_type = std::ptrdiff_t;
-  using pointer = Entry*;
-  using reference = Entry&;
+  using pointer = const Entry*;
+  using reference = const Entry&;
 
   theta_const_iterator(const Entry* entries, uint32_t size, uint32_t index);
   theta_const_iterator& operator++();
   theta_const_iterator operator++(int);
   bool operator==(const theta_const_iterator& other) const;
   bool operator!=(const theta_const_iterator& other) const;
-  const Entry& operator*() const;
+  reference operator*() const;
 
 private:
   const Entry* entries_;

--- a/theta/include/theta_update_sketch_base.hpp
+++ b/theta/include/theta_update_sketch_base.hpp
@@ -185,8 +185,14 @@ static inline uint64_t compute_hash(const void* data, size_t length, uint64_t se
 // iterators
 
 template<typename Entry, typename ExtractKey>
-class theta_iterator: public std::iterator<std::input_iterator_tag, Entry> {
+class theta_iterator {
 public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type = Entry;
+  using difference_type = std::ptrdiff_t;
+  using pointer = Entry*;
+  using reference = Entry&;
+
   theta_iterator(Entry* entries, uint32_t size, uint32_t index);
   theta_iterator& operator++();
   theta_iterator operator++(int);
@@ -201,8 +207,14 @@ private:
 };
 
 template<typename Entry, typename ExtractKey>
-class theta_const_iterator: public std::iterator<std::input_iterator_tag, Entry> {
+class theta_const_iterator {
 public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type = const Entry;
+  using difference_type = std::ptrdiff_t;
+  using pointer = Entry*;
+  using reference = Entry&;
+
   theta_const_iterator(const Entry* entries, uint32_t size, uint32_t index);
   theta_const_iterator& operator++();
   theta_const_iterator operator++(int);

--- a/theta/include/theta_update_sketch_base_impl.hpp
+++ b/theta/include/theta_update_sketch_base_impl.hpp
@@ -382,7 +382,7 @@ bool theta_iterator<Entry, ExtractKey>::operator==(const theta_iterator& other) 
 }
 
 template<typename Entry, typename ExtractKey>
-auto theta_iterator<Entry, ExtractKey>::operator*() const -> Entry& {
+auto theta_iterator<Entry, ExtractKey>::operator*() const -> reference {
   return entries_[index_];
 }
 


### PR DESCRIPTION
Not entirely confident on all the difference types, and I punted on the pointer type to a std::pair<> we return since I don't think it'll matter with how we use things.

Anyway, I don't expect this to be the final version but this does at least seem to work with both gcc and clang (14) for a few different c++ standards (11 and 20 at least)