### PR TITLE
Items support for quantile sketch family

### DIFF
--- a/python/include/py_object_lt.hpp
+++ b/python/include/py_object_lt.hpp
@@ -17,32 +17,21 @@
  * under the License.
  */
 
-#ifndef _PY_OBJECT_OSTREAM_HPP_
-#define _PY_OBJECT_OSTREAM_HPP_
+#ifndef _PY_OBJECT_LT_HPP_
+#define _PY_OBJECT_LT_HPP_
 
 #include <pybind11/pybind11.h>
 
-#include <string>
-#include <ostream>
-
 /*
-  This header defines an ostream output operator on a generic python
-  object. The implementation calls the object's built-in __str__()
+  This header defines a less than operator on generic python
+  objects. The implementation calls the object's built-in __lr__()
   method. If that method is not defined, the call may fail.
-
-  NOTE: This header must be included before the inclusion of
-        any sketch classes.
 */
 
-namespace py = pybind11;
+struct py_object_lt {
+  bool operator()(const pybind11::object& a, const pybind11::object& b) const {
+    return a < b;
+  }
+};
 
-namespace datasketches {
-
-static std::ostream& operator<<(std::ostream& os, const py::object& obj) {
-  os << std::string(pybind11::str(obj));
-  return os;
-}
-
-}
-
-#endif // _PY_OBJECT_OSTREAM_HPP_
+#endif // _PY_OBJECT_LT_HPP_

--- a/python/include/quantile_conditional.hpp
+++ b/python/include/quantile_conditional.hpp
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _QUANTILE_CONDITIONAL_HPP_
+#define _QUANTILE_CONDITIONAL_HPP_
+
+/*
+  This header defines conditionally compiled functions shared
+  across the set of quantile family sketches.
+*/
+
+#include "common_defs.hpp"
+#include "py_serde.hpp"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+
+namespace py = pybind11;
+
+// Serialization
+// std::string and arithmetic types, where we don't need a separate serde
+template<typename T, typename SK, typename std::enable_if<std::is_arithmetic<T>::value || std::is_same<std::string, T>::value, bool>::type = 0>
+void add_serialization(py::class_<SK>& clazz) {
+  clazz.def(
+        "serialize",
+        [](const SK& sk) {
+          auto bytes = sk.serialize();
+          return py::bytes(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+        },
+        "Serializes the sketch into a bytes object."
+    )
+    .def_static(
+        "deserialize",
+        [](const std::string& bytes) { return SK::deserialize(bytes.data(), bytes.size()); },
+        py::arg("bytes"),
+        "Deserializes the sketch from a bytes object."
+    );
+}
+
+// py::object and other types where the caller must provide a serde
+template<typename T, typename SK, typename std::enable_if<!std::is_arithmetic<T>::value && !std::is_same<std::string, T>::value, bool>::type = 0>
+void add_serialization(py::class_<SK>& clazz) {
+  clazz.def(
+        "serialize",
+        [](const SK& sk, datasketches::py_object_serde& serde) {
+          auto bytes = sk.serialize(0, serde);
+          return py::bytes(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+        }, py::arg("serde"),
+        "Serializes the sketch into a bytes object using the provided serde."
+    )
+    .def_static(
+        "deserialize",
+        [](const std::string& bytes, datasketches::py_object_serde& serde) {
+            return SK::deserialize(bytes.data(), bytes.size(), serde);
+        }, py::arg("bytes"), py::arg("serde"),
+        "Deserializes the sketch from a bytes object using the provided serde."
+    );
+}
+
+// Vector Updates
+// * Only allowed for POD types based on numpy restriction, which
+//   is equivalent to both std::is_trivial and std::is_standard_layout.
+// * Nothing is added to types that are not PODs.
+// POD type
+template<typename T, typename SK, typename std::enable_if<std::is_trivial<T>::value && std::is_standard_layout<T>::value, bool>::type = 0>
+void add_vector_update(py::class_<SK>& clazz) {
+  clazz.def(
+    "update",
+    [](SK& sk, py::array_t<T, py::array::c_style | py::array::forcecast> items) {
+      if (items.ndim() != 1) {
+        throw std::invalid_argument("input data must have only one dimension. Found: "
+          + std::to_string(items.ndim()));
+      }
+      auto array = items.template unchecked<1>();
+      for (uint32_t i = 0; i < array.size(); ++i) sk.update(array(i));
+    },
+    py::arg("array"),
+    "Updates the sketch with the values in the given array"
+  );
+}
+
+// non-POD type
+template<typename T, typename SK, typename std::enable_if<!std::is_trivial<T>::value || !std::is_standard_layout<T>::value, bool>::type = 0>
+void add_vector_update(py::class_<SK>& clazz) {
+  unused(clazz);
+}
+
+#endif // _QUANTILE_CONDITIONAL_HPP_

--- a/python/src/quantiles_wrapper.cpp
+++ b/python/src/quantiles_wrapper.cpp
@@ -17,63 +17,53 @@
  * under the License.
  */
 
+#include "py_object_lt.hpp"
+#include "py_object_ostream.hpp"
+#include "quantile_conditional.hpp"
+#include "quantiles_sketch.hpp"
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/numpy.h>
 #include <vector>
 #include <stdexcept>
 
-#include "quantiles_sketch.hpp"
-
 namespace py = pybind11;
 
-template<typename T>
+template<typename T, typename C>
 void bind_quantiles_sketch(py::module &m, const char* name) {
   using namespace datasketches;
 
-  py::class_<quantiles_sketch<T>>(m, name)
+  auto quantiles_class = py::class_<quantiles_sketch<T, C>>(m, name)
     .def(py::init<uint16_t>(), py::arg("k")=quantiles_constants::DEFAULT_K)
-    .def(py::init<const quantiles_sketch<T>&>())
+    .def(py::init<const quantiles_sketch<T, C>&>())
     .def(
         "update",
-        static_cast<void (quantiles_sketch<T>::*)(const T&)>(&quantiles_sketch<T>::update),
+        static_cast<void (quantiles_sketch<T, C>::*)(const T&)>(&quantiles_sketch<T, C>::update),
         py::arg("item"),
         "Updates the sketch with the given value"
     )
-    .def(
-        "update",
-        [](quantiles_sketch<T>& sk, py::array_t<T, py::array::c_style | py::array::forcecast> items) {
-          if (items.ndim() != 1) {
-            throw std::invalid_argument("input data must have only one dimension. Found: "
-              + std::to_string(items.ndim()));
-          }
-          auto array = items.template unchecked<1>();
-          for (uint32_t i = 0; i < array.size(); ++i) sk.update(array(i));
-        },
-        py::arg("array"),
-        "Updates the sketch with the values in the given array"
-    )
-    .def("merge", (void (quantiles_sketch<T>::*)(const quantiles_sketch<T>&)) &quantiles_sketch<T>::merge, py::arg("sketch"),
+    .def("merge", (void (quantiles_sketch<T, C>::*)(const quantiles_sketch<T, C>&)) &quantiles_sketch<T, C>::merge, py::arg("sketch"),
          "Merges the provided sketch into this one")
-    .def("__str__", &quantiles_sketch<T>::to_string, py::arg("print_levels")=false, py::arg("print_items")=false,
+    .def("__str__", &quantiles_sketch<T, C>::to_string, py::arg("print_levels")=false, py::arg("print_items")=false,
          "Produces a string summary of the sketch")
-    .def("to_string", &quantiles_sketch<T>::to_string, py::arg("print_levels")=false, py::arg("print_items")=false,
+    .def("to_string", &quantiles_sketch<T, C>::to_string, py::arg("print_levels")=false, py::arg("print_items")=false,
          "Produces a string summary of the sketch")
-    .def("is_empty", &quantiles_sketch<T>::is_empty,
+    .def("is_empty", &quantiles_sketch<T, C>::is_empty,
          "Returns True if the sketch is empty, otherwise False")
-    .def("get_k", &quantiles_sketch<T>::get_k,
+    .def("get_k", &quantiles_sketch<T, C>::get_k,
          "Returns the configured parameter k")
-    .def("get_n", &quantiles_sketch<T>::get_n,
+    .def("get_n", &quantiles_sketch<T, C>::get_n,
          "Returns the length of the input stream")
-    .def("get_num_retained", &quantiles_sketch<T>::get_num_retained,
+    .def("get_num_retained", &quantiles_sketch<T, C>::get_num_retained,
          "Returns the number of retained items (samples) in the sketch")
-    .def("is_estimation_mode", &quantiles_sketch<T>::is_estimation_mode,
+    .def("is_estimation_mode", &quantiles_sketch<T, C>::is_estimation_mode,
          "Returns True if the sketch is in estimation mode, otherwise False")
-    .def("get_min_value", &quantiles_sketch<T>::get_min_item,
+    .def("get_min_value", &quantiles_sketch<T, C>::get_min_item,
          "Returns the minimum value from the stream. If empty, quantiles_floats_sketch returns nan; quantiles_ints_sketch throws a RuntimeError")
-    .def("get_max_value", &quantiles_sketch<T>::get_max_item,
+    .def("get_max_value", &quantiles_sketch<T, C>::get_max_item,
          "Returns the maximum value from the stream. If empty, quantiles_floats_sketch returns nan; quantiles_ints_sketch throws a RuntimeError")
-    .def("get_quantile", &quantiles_sketch<T>::get_quantile, py::arg("rank"), py::arg("inclusive")=false,
+    .def("get_quantile", &quantiles_sketch<T, C>::get_quantile, py::arg("rank"), py::arg("inclusive")=false,
          "Returns an approximation to the data value "
          "associated with the given rank in a hypothetical sorted "
          "version of the input stream so far.\n"
@@ -81,7 +71,7 @@ void bind_quantiles_sketch(py::module &m, const char* name) {
          "For quantiles_ints_sketch: if the sketch is empty this throws a RuntimeError.")
     .def(
         "get_quantiles",
-        [](const quantiles_sketch<T>& sk, const std::vector<double>& ranks, bool inclusive) {
+        [](const quantiles_sketch<T, C>& sk, const std::vector<double>& ranks, bool inclusive) {
           return sk.get_quantiles(ranks.data(), ranks.size(), inclusive);
         },
         py::arg("ranks"), py::arg("inclusive")=false,
@@ -90,7 +80,7 @@ void bind_quantiles_sketch(py::module &m, const char* name) {
         "If the sketch is empty this returns an empty vector.\n"
         "Deprecated. Will be removed in the next major version. Use get_quantile() instead."
     )
-    .def("get_rank", &quantiles_sketch<T>::get_rank, py::arg("value"), py::arg("inclusive")=false,
+    .def("get_rank", &quantiles_sketch<T, C>::get_rank, py::arg("value"), py::arg("inclusive")=false,
          "Returns an approximation to the normalized rank of the given value from 0 to 1, inclusive.\n"
          "The resulting approximation has a probabilistic guarantee that can be obtained from the "
          "get_normalized_rank_error(False) function.\n"
@@ -99,7 +89,7 @@ void bind_quantiles_sketch(py::module &m, const char* name) {
          "If the sketch is empty this returns nan.")
     .def(
         "get_pmf",
-        [](const quantiles_sketch<T>& sk, const std::vector<T>& split_points, bool inclusive) {
+        [](const quantiles_sketch<T, C>& sk, const std::vector<T>& split_points, bool inclusive) {
           return sk.get_PMF(split_points.data(), split_points.size(), inclusive);
         },
         py::arg("split_points"), py::arg("inclusive")=false,
@@ -117,7 +107,7 @@ void bind_quantiles_sketch(py::module &m, const char* name) {
     )
     .def(
         "get_cdf",
-        [](const quantiles_sketch<T>& sk, const std::vector<T>& split_points, bool inclusive) {
+        [](const quantiles_sketch<T, C>& sk, const std::vector<T>& split_points, bool inclusive) {
           return sk.get_CDF(split_points.data(), split_points.size(), inclusive);
         },
         py::arg("split_points"), py::arg("inclusive")=false,
@@ -135,7 +125,7 @@ void bind_quantiles_sketch(py::module &m, const char* name) {
     )
     .def(
         "normalized_rank_error",
-        static_cast<double (quantiles_sketch<T>::*)(bool) const>(&quantiles_sketch<T>::get_normalized_rank_error),
+        static_cast<double (quantiles_sketch<T, C>::*)(bool) const>(&quantiles_sketch<T, C>::get_normalized_rank_error),
         py::arg("as_pmf"),
         "Gets the normalized rank error for this sketch.\n"
         "If pmf is True, returns the 'double-sided' normalized rank error for the get_PMF() function.\n"
@@ -144,32 +134,22 @@ void bind_quantiles_sketch(py::module &m, const char* name) {
     )
     .def_static(
         "get_normalized_rank_error",
-        [](uint16_t k, bool pmf) { return quantiles_sketch<T>::get_normalized_rank_error(k, pmf); },
+        [](uint16_t k, bool pmf) { return quantiles_sketch<T, C>::get_normalized_rank_error(k, pmf); },
         py::arg("k"), py::arg("as_pmf"),
         "Gets the normalized rank error given parameters k and the pmf flag.\n"
         "If pmf is True, returns the 'double-sided' normalized rank error for the get_PMF() function.\n"
         "Otherwise, it is the 'single-sided' normalized rank error for all the other queries.\n"
         "Constants were derived as the best fit to 99 percentile empirically measured max error in thousands of trials"
     )
-    .def(
-        "serialize",
-        [](const quantiles_sketch<T>& sk) {
-          auto bytes = sk.serialize();
-          return py::bytes(reinterpret_cast<const char*>(bytes.data()), bytes.size());
-        },
-        "Serializes the sketch into a bytes object"
-    )
-    .def_static(
-        "deserialize",
-        [](const std::string& bytes) { return quantiles_sketch<T>::deserialize(bytes.data(), bytes.size()); },
-        py::arg("bytes"),
-        "Deserializes the sketch from a bytes object"
-    )
-    .def("__iter__", [](const quantiles_sketch<T>& s) { return py::make_iterator(s.begin(), s.end()); });
+    .def("__iter__", [](const quantiles_sketch<T, C>& s) { return py::make_iterator(s.begin(), s.end()); });
+
+    add_serialization<T>(quantiles_class);
+    add_vector_update<T>(quantiles_class);
 }
 
 void init_quantiles(py::module &m) {
-  bind_quantiles_sketch<int>(m, "quantiles_ints_sketch");
-  bind_quantiles_sketch<float>(m, "quantiles_floats_sketch");
-  bind_quantiles_sketch<double>(m, "quantiles_doubles_sketch");
+  bind_quantiles_sketch<int, std::less<int>>(m, "quantiles_ints_sketch");
+  bind_quantiles_sketch<float, std::less<float>>(m, "quantiles_floats_sketch");
+  bind_quantiles_sketch<double, std::less<double>>(m, "quantiles_doubles_sketch");
+  bind_quantiles_sketch<py::object, py_object_lt>(m, "quantiles_items_sketch");
 }

--- a/python/tests/quantiles_test.py
+++ b/python/tests/quantiles_test.py
@@ -16,11 +16,12 @@
 # under the License.
 
 import unittest
-from datasketches import quantiles_ints_sketch, quantiles_floats_sketch, quantiles_doubles_sketch, ks_test
+from datasketches import quantiles_ints_sketch, quantiles_floats_sketch, quantiles_doubles_sketch
+from datasketches import quantiles_items_sketch, ks_test, PyStringsSerDe
 import numpy as np
 
 class QuantilesTest(unittest.TestCase):
-    def test_quantiles_example(self):
+    def test_quantiles_floats_example(self):
       k = 128
       n = 2 ** 20
 
@@ -61,12 +62,13 @@ class QuantilesTest(unittest.TestCase):
       self.assertLess(quantiles.get_num_retained(), n)
 
       # merging itself will double the number of items the sketch has seen
-      quantiles.merge(quantiles)
+      quantiles_copy = quantiles_floats_sketch(quantiles)
+      quantiles.merge(quantiles_copy)
       self.assertEqual(quantiles.get_n(), 2*n)
 
       # we can then serialize and reconstruct the sketch
       quantiles_bytes = quantiles.serialize()
-      new_quantiles = quantiles.deserialize(quantiles_bytes)
+      new_quantiles = quantiles_floats_sketch.deserialize(quantiles_bytes)
       self.assertEqual(quantiles.get_num_retained(), new_quantiles.get_num_retained())
       self.assertEqual(quantiles.get_min_value(), new_quantiles.get_min_value())
       self.assertEqual(quantiles.get_max_value(), new_quantiles.get_max_value())
@@ -117,7 +119,8 @@ class QuantilesTest(unittest.TestCase):
         self.assertEqual(quantiles.get_rank(round(n/2)), 0.5)
 
         # merge self
-        quantiles.merge(quantiles)
+        quantiles_copy = quantiles_ints_sketch(quantiles)
+        quantiles.merge(quantiles_copy)
         self.assertEqual(quantiles.get_n(), 2 * n)
 
         sk_bytes = quantiles.serialize()
@@ -128,6 +131,30 @@ class QuantilesTest(unittest.TestCase):
       k = 128
       quantiles = quantiles_doubles_sketch(k)
       self.assertTrue(quantiles.is_empty())
+
+    def test_quantiles_items_sketch(self):
+      # most functionality has been tested, but we need to ensure objects and sorting work
+      # as well as serialization
+      k = 128
+      n = 2 ** 16
+
+      # create a sketch and inject enough points to force compaction
+      quantiles = quantiles_items_sketch(k)
+      for i in range(0, n):
+        quantiles.update(str(i))
+      
+      quantiles_copy = quantiles_items_sketch(quantiles)
+      quantiles.merge(quantiles_copy)
+      self.assertEqual(quantiles.get_n(), 2 * n)
+      
+      quantiles_bytes = quantiles.serialize(PyStringsSerDe())
+      new_quantiles = quantiles_items_sketch.deserialize(quantiles_bytes, PyStringsSerDe())
+      self.assertEqual(quantiles.get_num_retained(), new_quantiles.get_num_retained())
+      self.assertEqual(quantiles.get_min_value(), new_quantiles.get_min_value())
+      self.assertEqual(quantiles.get_max_value(), new_quantiles.get_max_value())
+      self.assertEqual(quantiles.get_quantile(0.7), new_quantiles.get_quantile(0.7))
+      self.assertEqual(quantiles.get_rank(str(n/4)), new_quantiles.get_rank(str(n/4)))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/quantiles/include/quantiles_sketch_impl.hpp
+++ b/quantiles/include/quantiles_sketch_impl.hpp
@@ -645,12 +645,12 @@ string<A> quantiles_sketch<T, C, A>::to_string(bool print_levels, bool print_ite
     uint8_t level = 0;
     os << " BB:" << std::endl;
     for (const T& item : base_buffer_) {
-      os << "    " << std::to_string(item) << std::endl;
+      os << "    " << item << std::endl;
     }
     for (uint8_t i = 0; i < levels_.size(); ++i) {
       os << " level " << static_cast<unsigned int>(level) << ":" << std::endl;
       for (const T& item : levels_[i]) {
-        os << "   " << std::to_string(item) << std::endl;
+        os << "   " << item << std::endl;
       }
     }
     os << "### End sketch data" << std::endl;


### PR DESCRIPTION
Our quantiles algorithms aren't the most compact, but they do benefit from being fully value-agnostic -- to the point where all we require is a less-than comparator. We've had support for generic items in Java and C++, and this should add it for python.

I had to change a couple uses of std::to_string() in the non-python legacy quantiles implementation to use the ostream operator. I believe this is safe and does not change the API since std::to_string() can't be overridden and the types for which it works also have an ostream operator defined. No need for a major version bump as a result of this PR.