### PR TITLE
Count min python

### DIFF
--- a/count/include/count_min.hpp
+++ b/count/include/count_min.hpp
@@ -183,7 +183,7 @@ public:
    * @brief Returns a string describing the sketch
    * @return A string with a human-readable description of the sketch
    */
-  string<std::allocator<char>> to_string() const;
+  string<std::allocator<W>> to_string() const;
 
   // Iterators
   using const_iterator = typename std::vector<W>::const_iterator ;

--- a/count/include/count_min.hpp
+++ b/count/include/count_min.hpp
@@ -21,29 +21,29 @@ public:
 
   using vector_bytes = std::vector<uint8_t>;
   /**
-  * Creates an instance of the sketch given parameters _num_hashes, _num_buckets and hash seed, `seed`.
-  * @param num_hashes : number of hash functions in the sketch. Equivalently the number of rows in the array
-  * @param num_buckets : number of buckets that hash functions map into. Equivalently the number of columns in the array
-  * @param seed for hash function
-  *
-  * The items inserted into the sketch can be arbitrary type, so long as they are hashable via murmurhash.
-  * Only update and estimate methods are added for uint64_t and string types.
-  */
+   * Creates an instance of the sketch given parameters _num_hashes, _num_buckets and hash seed, `seed`.
+   * @param num_hashes : number of hash functions in the sketch. Equivalently the number of rows in the array
+   * @param num_buckets : number of buckets that hash functions map into. Equivalently the number of columns in the array
+   * @param seed for hash function
+   *
+   * The items inserted into the sketch can be arbitrary type, so long as they are hashable via murmurhash.
+   * Only update and estimate methods are added for uint64_t and string types.
+   */
   count_min_sketch(uint8_t num_hashes, uint32_t num_buckets, uint64_t seed = DEFAULT_SEED) ;
 
   /**
-  * @return configured _num_hashes of this sketch
-  */
+   * @return configured _num_hashes of this sketch
+   */
   uint8_t get_num_hashes() const;
 
   /**
-  * @return configured _num_buckets of this sketch
-  */
+   * @return configured _num_buckets of this sketch
+   */
   uint32_t get_num_buckets() const;
 
   /**
-  * @return configured seed of this sketch
-  */
+   * @return configured seed of this sketch
+   */
   uint64_t get_seed()  const;
 
   /**
@@ -54,20 +54,20 @@ public:
    double get_relative_error() const;
 
   /**
-  * @return _total_weight : typename W
-  * The total weight currently inserted into the stream.
-  */
+   * @return _total_weight : typename W
+   * The total weight currently inserted into the stream.
+   */
   W get_total_weight() const;
 
   /*
- * @param relative_error : double -- the desired accuracy within which estimates should lie.
- * For example, when relative_error = 0.05, then the returned frequency estimates satisfy the
- * `relative_error` guarantee that never overestimates the weights but may underestimate the weights
- * by 5% of the total weight in the sketch.
- * @return number_of_buckets : the number of hash buckets at every level of the
- * sketch required in order to obtain the specified relative error.
- * [1] - Section 3 ``Data Structure'', page 6.
- */
+   * @param relative_error : double -- the desired accuracy within which estimates should lie.
+   * For example, when relative_error = 0.05, then the returned frequency estimates satisfy the
+   * `relative_error` guarantee that never overestimates the weights but may underestimate the weights
+   * by 5% of the total weight in the sketch.
+   * @return number_of_buckets : the number of hash buckets at every level of the
+   * sketch required in order to obtain the specified relative error.
+   * [1] - Section 3 ``Data Structure'', page 6.
+   */
   static uint32_t suggest_num_buckets(double relative_error) ;
 
   /*
@@ -77,7 +77,7 @@ public:
    * order to achieve the specified confidence of the sketch.
    * confidence = 1 - delta, with delta denoting the sketch failure probability in the literature.
    * [1] - Section 3 ``Data Structure'', page 6.
-  */
+   */
   static uint8_t suggest_num_hashes(double confidence) ;
 
   /**
@@ -88,7 +88,15 @@ public:
    */
   W get_estimate(uint64_t item) const ;
 
-   /**
+  /**
+   * Specific get_estimate function for int64_t type
+   * see generic get_estimate function
+   * @param item : uint64_t type.
+   * @return an estimate of the item's frequency.
+   */
+  W get_estimate(int64_t item) const ;
+
+  /**
    * Specific get_estimate function for std::string type
    * see generic get_estimate function
    * @param item : std::string type
@@ -97,51 +105,53 @@ public:
   W get_estimate(const std::string& item) const;
 
   /**
-  * This is the generic estimate query function for any of the given datatypes.
-  * Query the sketch for the estimate of a given item.
-  * @param item : pointer to the data item to be query from the sketch.
-  * @param size : size_t
-  * @return the estimated frequency of the item denoted f_est satisfying
-  * f_true - relative_error*_total_weight <= f_est <= f_true
-  */
-   W get_estimate(const void* item, size_t size) const ;
+   * This is the generic estimate query function for any of the given datatypes.
+   * Query the sketch for the estimate of a given item.
+   * @param item : pointer to the data item to be query from the sketch.
+   * @param size : size_t
+   * @return the estimated frequency of the item denoted f_est satisfying
+   * f_true - relative_error*_total_weight <= f_est <= f_true
+   */
+  W get_estimate(const void* item, size_t size) const ;
 
   /**
-  * Query the sketch for the upper bound of a given item.
-  * @param item : uint64_t or std::string to query
-  * @return the upper bound on the true frequency of the item
-  * f_true <= f_est + relative_error*_total_weight
-  */
-   W get_upper_bound(const void* item, size_t size) const;
-   W get_upper_bound(uint64_t) const ;
-   W get_upper_bound(const std::string& item) const;
+   * Query the sketch for the upper bound of a given item.
+   * @param item : uint64_t or std::string to query
+   * @return the upper bound on the true frequency of the item
+   * f_true <= f_est + relative_error*_total_weight
+   */
+  W get_upper_bound(const void* item, size_t size) const;
+  W get_upper_bound(int64_t) const ;
+  W get_upper_bound(uint64_t) const ;
+  W get_upper_bound(const std::string& item) const;
 
   /**
-  * Query the sketch for the lower bound of a given item.
-  * @param item : uint64_t or std::string to query
-  * @return the lower bound for the query result, f_est, on the true frequency, f_est of the item
-  * f_true - relative_error*_total_weight <= f_est
-  */
+   * Query the sketch for the lower bound of a given item.
+   * @param item : uint64_t or std::string to query
+   * @return the lower bound for the query result, f_est, on the true frequency, f_est of the item
+   * f_true - relative_error*_total_weight <= f_est
+   */
   W get_lower_bound(const void* item, size_t size) const ;
+  W get_lower_bound(int64_t) const ;
   W get_lower_bound(uint64_t) const ;
   W get_lower_bound(const std::string& item) const ;
 
   /*
-  * Update this sketch with given data of any type.
-  * This is a "universal" update that covers all cases above,
-  * but may produce different hashes.
-  * @param item pointer to the data item to be inserted into the sketch.
-  * @param size of the data in bytes
-  * @return vector of uint64_t which each represent the index to which `value' must update in the sketch
-  */
+   * Update this sketch with given data of any type.
+   * This is a "universal" update that covers all cases above,
+   * but may produce different hashes.
+   * @param item pointer to the data item to be inserted into the sketch.
+   * @param size of the data in bytes
+   * @return vector of uint64_t which each represent the index to which `value' must update in the sketch
+   */
   void update(const void* item, size_t size, W weight) ;
 
   /**
-  * Update this sketch with a given uint64_t item.
-  * @param item : uint64_t to update the sketch with
-  * @param weight : arithmetic type
-  *  void function which inserts an item of type uint64_t into the sketch
-  */
+   * Update this sketch with a given uint64_t item.
+   * @param item : uint64_t to update the sketch with
+   * @param weight : arithmetic type
+   *  void function which inserts an item of type uint64_t into the sketch
+   */
   void update(uint64_t item, W weight) ;
   void update(uint64_t item) ;
   void update(int64_t item, W weight) ;
@@ -157,8 +167,8 @@ public:
   void update(const std::string& item) ;
 
   /*
-  * merges a separate count_min_sketch into this count_min_sketch.
-  */
+   * merges a separate count_min_sketch into this count_min_sketch.
+   */
   void merge(const count_min_sketch<W> &other_sketch) ;
 
   /**
@@ -168,6 +178,12 @@ public:
    * @return empty flag
    */
   bool is_empty() const ;
+
+  /**
+   * @brief Returns a string describing the sketch
+   * @return A string with a human-readable description of the sketch
+   */
+  string<std::allocator<char>> to_string() const;
 
   // Iterators
   using const_iterator = typename std::vector<W>::const_iterator ;
@@ -234,21 +250,21 @@ public:
   vector_bytes serialize(unsigned header_size_bytes = 0) const;
 
   /**
- * This method deserializes a sketch from a given stream.
- * @param is input stream
- * @param seed the seed for the hash function that was used to create the sketch
- * @return an instance of a sketch
- */
+  * This method deserializes a sketch from a given stream.
+  * @param is input stream
+  * @param seed the seed for the hash function that was used to create the sketch
+  * @return an instance of a sketch
+  */
   //static count_min_sketch deserialize(std::istream& is, uint64_t seed=DEFAULT_SEED) const;
   static count_min_sketch deserialize(std::istream& is, uint64_t seed) ;
 
   /**
- * This method deserializes a sketch from a given array of bytes.
- * @param bytes pointer to the array of bytes
- * @param size the size of the array
- * @param seed the seed for the hash function that was used to create the sketch
- * @return an instance of the sketch
- */
+  * This method deserializes a sketch from a given array of bytes.
+  * @param bytes pointer to the array of bytes
+  * @param size the size of the array
+  * @param seed the seed for the hash function that was used to create the sketch
+  * @return an instance of the sketch
+  */
   static count_min_sketch deserialize(const void* bytes, size_t size, uint64_t seed=DEFAULT_SEED);
 
 private:

--- a/count/include/count_min_impl.hpp
+++ b/count/include/count_min_impl.hpp
@@ -450,7 +450,7 @@ bool count_min_sketch<W>::is_empty() const {
 }
 
 template<typename W>
-string<std::allocator<char>> count_min_sketch<W>::to_string() const {
+string<std::allocator<W>> count_min_sketch<W>::to_string() const {
   // count the number of used entries in the sketch
   uint64_t num_nonzero = 0;
   for (auto entry : _sketch_array) {
@@ -461,7 +461,7 @@ string<std::allocator<char>> count_min_sketch<W>::to_string() const {
   // Using a temporary stream for implementation here does not comply with AllocatorAwareContainer requirements.
   // The stream does not support passing an allocator instance, and alternatives are complicated.
   std::ostringstream os;
-  os << "### KLL sketch summary:" << std::endl;
+  os << "### Count Min sketch summary:" << std::endl;
   os << "   num hashes     : " << static_cast<uint32_t>(_num_hashes) << std::endl;
   os << "   num buckets    : " << _num_buckets << std::endl;
   os << "   capacity bins  : " << _sketch_array.size() << std::endl;
@@ -470,7 +470,7 @@ string<std::allocator<char>> count_min_sketch<W>::to_string() const {
   os << "### End sketch summary" << std::endl;
 
   //return string<A>(os.str().c_str(), allocator_);
-  return string<std::allocator<char>>(os.str().c_str());
+  return string<std::allocator<W>>(os.str().c_str());
 }
 
 template<typename W>

--- a/count/include/count_min_impl.hpp
+++ b/count/include/count_min_impl.hpp
@@ -363,7 +363,7 @@ size_t count_min_sketch<W,A>::get_serialized_size_bytes() const {
 
   // If the sketch is empty, we're done. Otherwise, we need the total weight
   // held by the sketch as well as a data table of size (num_buckets * num_hashes)
-  return preamble_longs + (is_empty() ? 0 : sizeof(W) * (1 + _num_buckets * _num_hashes));
+  return (preamble_longs * sizeof(uint64_t)) + (is_empty() ? 0 : sizeof(W) * (1 + _num_buckets * _num_hashes));
 }
 
 template<typename W, typename A>

--- a/count/include/count_min_impl.hpp
+++ b/count/include/count_min_impl.hpp
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 #ifndef COUNT_MIN_IMPL_HPP_
 #define COUNT_MIN_IMPL_HPP_
 
@@ -11,11 +30,12 @@
 
 namespace datasketches {
 
-template<typename W>
-count_min_sketch<W>::count_min_sketch(uint8_t num_hashes, uint32_t num_buckets, uint64_t seed):
+template<typename W, typename A>
+count_min_sketch<W,A>::count_min_sketch(uint8_t num_hashes, uint32_t num_buckets, uint64_t seed, const A& allocator):
+_allocator(allocator),
 _num_hashes(num_hashes),
 _num_buckets(num_buckets),
-_sketch_array((num_hashes*num_buckets < 1<<30) ? num_hashes*num_buckets : 0, 0),
+_sketch_array((num_hashes*num_buckets < 1<<30) ? num_hashes*num_buckets : 0, 0, _allocator),
 _seed(seed),
 _total_weight(0){
   if(num_buckets < 3) throw std::invalid_argument("Using fewer than 3 buckets incurs relative error greater than 1.") ;
@@ -27,7 +47,6 @@ _total_weight(0){
                                 "Try reducing either the number of buckets or the number of hash functions.") ;
   }
 
-
   std::default_random_engine rng(_seed);
   std::uniform_int_distribution<uint64_t> extra_hash_seeds(0, std::numeric_limits<uint64_t>::max());
   hash_seeds.reserve(num_hashes) ;
@@ -37,33 +56,33 @@ _total_weight(0){
   }
 }
 
-template<typename W>
-uint8_t count_min_sketch<W>::get_num_hashes() const{
+template<typename W, typename A>
+uint8_t count_min_sketch<W,A>::get_num_hashes() const{
     return _num_hashes ;
 }
 
-template<typename W>
-uint32_t count_min_sketch<W>::get_num_buckets() const{
+template<typename W, typename A>
+uint32_t count_min_sketch<W,A>::get_num_buckets() const{
     return _num_buckets ;
 }
 
-template<typename W>
-uint64_t count_min_sketch<W>::get_seed() const {
+template<typename W, typename A>
+uint64_t count_min_sketch<W,A>::get_seed() const {
     return _seed ;
 }
 
-template<typename W>
-double count_min_sketch<W>::get_relative_error() const{
+template<typename W, typename A>
+double count_min_sketch<W,A>::get_relative_error() const{
   return exp(1.0) / double(_num_buckets) ;
 }
 
-template<typename W>
-W count_min_sketch<W>::get_total_weight() const{
+template<typename W, typename A>
+W count_min_sketch<W,A>::get_total_weight() const{
   return _total_weight ;
 }
 
-template<typename W>
-uint32_t count_min_sketch<W>::suggest_num_buckets(double relative_error){
+template<typename W, typename A>
+uint32_t count_min_sketch<W,A>::suggest_num_buckets(double relative_error){
   /*
    * Function to help users select a number of buckets for a given error.
    * TODO: Change this when we use only power of 2 buckets.
@@ -75,8 +94,8 @@ uint32_t count_min_sketch<W>::suggest_num_buckets(double relative_error){
   return ceil(exp(1.0) / relative_error);
 }
 
-template<typename W>
-uint8_t count_min_sketch<W>::suggest_num_hashes(double confidence){
+template<typename W, typename A>
+uint8_t count_min_sketch<W,A>::suggest_num_hashes(double confidence){
   /*
    * Function to help users select a number of hashes for a given confidence
    * e.g. confidence = 1 - failure probability
@@ -88,8 +107,8 @@ uint8_t count_min_sketch<W>::suggest_num_hashes(double confidence){
   return std::min<uint8_t>( ceil(log(1.0/(1.0 - confidence))), UINT8_MAX) ;
 }
 
-template<typename W>
-std::vector<uint64_t> count_min_sketch<W>::get_hashes(const void* item, size_t size) const{
+template<typename W, typename A>
+std::vector<uint64_t> count_min_sketch<W,A>::get_hashes(const void* item, size_t size) const{
   /*
    * Returns the hash locations for the input item using the original hashing
    * scheme from [1].
@@ -120,20 +139,20 @@ std::vector<uint64_t> count_min_sketch<W>::get_hashes(const void* item, size_t s
   return sketch_update_locations ;
 }
 
-template<typename W>
-W count_min_sketch<W>::get_estimate(uint64_t item) const {return get_estimate(&item, sizeof(item));}
+template<typename W, typename A>
+W count_min_sketch<W,A>::get_estimate(uint64_t item) const {return get_estimate(&item, sizeof(item));}
 
-template<typename W>
-W count_min_sketch<W>::get_estimate(int64_t item) const {return get_estimate(&item, sizeof(item));}
+template<typename W, typename A>
+W count_min_sketch<W,A>::get_estimate(int64_t item) const {return get_estimate(&item, sizeof(item));}
 
-template<typename W>
-W count_min_sketch<W>::get_estimate(const std::string& item) const {
+template<typename W, typename A>
+W count_min_sketch<W,A>::get_estimate(const std::string& item) const {
   if (item.empty()) return 0 ; // Empty strings are not inserted into the sketch.
   return get_estimate(item.c_str(), item.length());
 }
 
-template<typename W>
-W count_min_sketch<W>::get_estimate(const void* item, size_t size) const {
+template<typename W, typename A>
+W count_min_sketch<W,A>::get_estimate(const void* item, size_t size) const {
   /*
    * Returns the estimated frequency of the item
    */
@@ -146,40 +165,40 @@ W count_min_sketch<W>::get_estimate(const void* item, size_t size) const {
   return result ;
 }
 
-template<typename W>
-void count_min_sketch<W>::update(uint64_t item, W weight) {
+template<typename W, typename A>
+void count_min_sketch<W,A>::update(uint64_t item, W weight) {
   update(&item, sizeof(item), weight);
 }
 
-template<typename W>
-void count_min_sketch<W>::update(uint64_t item) {
+template<typename W, typename A>
+void count_min_sketch<W,A>::update(uint64_t item) {
   update(&item, sizeof(item), 1);
 }
 
-template<typename W>
-void count_min_sketch<W>::update(int64_t item, W weight) {
+template<typename W, typename A>
+void count_min_sketch<W,A>::update(int64_t item, W weight) {
   update(&item, sizeof(item), weight);
 }
 
-template<typename W>
-void count_min_sketch<W>::update(int64_t item) {
+template<typename W, typename A>
+void count_min_sketch<W,A>::update(int64_t item) {
   update(&item, sizeof(item), 1);
 }
 
-template<typename W>
-void count_min_sketch<W>::update(const std::string& item, W weight) {
+template<typename W, typename A>
+void count_min_sketch<W,A>::update(const std::string& item, W weight) {
   if (item.empty()) return;
   update(item.c_str(), item.length(), weight);
 }
 
-template<typename W>
-void count_min_sketch<W>::update(const std::string& item) {
+template<typename W, typename A>
+void count_min_sketch<W,A>::update(const std::string& item) {
   if (item.empty()) return;
   update(item.c_str(), item.length(), 1);
 }
 
-template<typename W>
-void count_min_sketch<W>::update(const void* item, size_t size, W weight) {
+template<typename W, typename A>
+void count_min_sketch<W,A>::update(const void* item, size_t size, W weight) {
   /*
    * Gets the item's hash locations and then increments the sketch in those
    * locations by the weight.
@@ -192,42 +211,42 @@ void count_min_sketch<W>::update(const void* item, size_t size, W weight) {
   }
 }
 
-template<typename W>
-W count_min_sketch<W>::get_upper_bound(uint64_t item) const {return get_upper_bound(&item, sizeof(item));}
+template<typename W, typename A>
+W count_min_sketch<W,A>::get_upper_bound(uint64_t item) const {return get_upper_bound(&item, sizeof(item));}
 
-template<typename W>
-W count_min_sketch<W>::get_upper_bound(int64_t item) const {return get_upper_bound(&item, sizeof(item));}
+template<typename W, typename A>
+W count_min_sketch<W,A>::get_upper_bound(int64_t item) const {return get_upper_bound(&item, sizeof(item));}
 
-template<typename W>
-W count_min_sketch<W>::get_upper_bound(const std::string& item) const {
+template<typename W, typename A>
+W count_min_sketch<W,A>::get_upper_bound(const std::string& item) const {
   if (item.empty()) return 0 ; // Empty strings are not inserted into the sketch.
   return get_upper_bound(item.c_str(), item.length());
 }
 
-template<typename W>
-W count_min_sketch<W>::get_upper_bound(const void* item, size_t size) const {
+template<typename W, typename A>
+W count_min_sketch<W,A>::get_upper_bound(const void* item, size_t size) const {
   return get_estimate(item, size) + get_relative_error()*get_total_weight() ;
 }
 
-template<typename W>
-W count_min_sketch<W>::get_lower_bound(uint64_t item) const {return get_lower_bound(&item, sizeof(item));}
+template<typename W, typename A>
+W count_min_sketch<W,A>::get_lower_bound(uint64_t item) const {return get_lower_bound(&item, sizeof(item));}
 
-template<typename W>
-W count_min_sketch<W>::get_lower_bound(int64_t item) const {return get_lower_bound(&item, sizeof(item));}
+template<typename W, typename A>
+W count_min_sketch<W,A>::get_lower_bound(int64_t item) const {return get_lower_bound(&item, sizeof(item));}
 
-template<typename W>
-W count_min_sketch<W>::get_lower_bound(const std::string& item) const {
+template<typename W, typename A>
+W count_min_sketch<W,A>::get_lower_bound(const std::string& item) const {
   if (item.empty()) return 0 ; // Empty strings are not inserted into the sketch.
   return get_lower_bound(item.c_str(), item.length());
 }
 
-template<typename W>
-W count_min_sketch<W>::get_lower_bound(const void* item, size_t size) const {
+template<typename W, typename A>
+W count_min_sketch<W,A>::get_lower_bound(const void* item, size_t size) const {
   return get_estimate(item, size) ;
 }
 
-template<typename W>
-void count_min_sketch<W>::merge(const count_min_sketch<W> &other_sketch){
+template<typename W, typename A>
+void count_min_sketch<W,A>::merge(const count_min_sketch &other_sketch){
   /*
   * Merges this sketch into other_sketch sketch by elementwise summing of buckets
   */
@@ -255,29 +274,21 @@ void count_min_sketch<W>::merge(const count_min_sketch<W> &other_sketch){
 }
 
 // Iterators
-template<typename W>
-typename count_min_sketch<W>::const_iterator count_min_sketch<W>::begin() const {
+template<typename W, typename A>
+typename count_min_sketch<W,A>::const_iterator count_min_sketch<W,A>::begin() const {
   return _sketch_array.begin();
 }
 
-template<typename W>
-typename count_min_sketch<W>::const_iterator count_min_sketch<W>::end() const {
+template<typename W, typename A>
+typename count_min_sketch<W,A>::const_iterator count_min_sketch<W,A>::end() const {
 return _sketch_array.end();
 }
 
-template<typename W>
-void count_min_sketch<W>::serialize(std::ostream& os) const {
-  // Variable table bytes is used to determine how many bytes to allocate for the sketch table.
-  // We assume that 8 bytes are necessary per entry in the table.
-  // The extra 1 is for the total_weight variable which will be zero iff the sketch is empty.
-  // Hence, table_bytes == 0 iff sketch is empty <=> preamble_longs == 1
-  const size_t table_bytes(is_empty() ? 0 : (1 + _num_hashes) * _num_buckets);
-  const size_t size = sizeof(uint64_t) * (2 + table_bytes);
-  vector_bytes bytes(size, 0);
-
+template<typename W, typename A>
+void count_min_sketch<W,A>::serialize(std::ostream& os) const {
   // Long 0
-  // The first 4 (of 8) bytes are either 1 or 0 (denoting empty vs non-empty) and the final 4 bytes are unused.
-  const uint8_t preamble_longs = is_empty() ? PREAMBLE_LONGS_SHORT : PREAMBLE_LONGS_FULL;
+  //const uint8_t preamble_longs = is_empty() ? PREAMBLE_LONGS_SHORT : PREAMBLE_LONGS_FULL;
+  const uint8_t preamble_longs = PREAMBLE_LONGS_SHORT;
   const uint8_t ser_ver = SERIAL_VERSION_1;
   const uint8_t family_id = FAMILY_ID ;
   const uint8_t flags_byte = (is_empty() ? 1 << flags::IS_EMPTY : 0);
@@ -311,8 +322,8 @@ void count_min_sketch<W>::serialize(std::ostream& os) const {
   }
 }
 
-template<typename W>
-count_min_sketch<W> count_min_sketch<W>::deserialize(std::istream& is, uint64_t seed) {
+template<typename W, typename A>
+auto count_min_sketch<W,A>::deserialize(std::istream& is, uint64_t seed, const A& allocator) -> count_min_sketch {
 
   // First 8 bytes are 4 bytes of preamble and 4 unused bytes.
   const auto preamble_longs = read<uint8_t>(is) ;
@@ -333,7 +344,7 @@ count_min_sketch<W> count_min_sketch<W>::deserialize(std::istream& is, uint64_t 
     throw std::invalid_argument("Incompatible seed hashes: " + std::to_string(seed_hash) + ", "
                                 + std::to_string(compute_seed_hash(seed)));
   }
-  count_min_sketch<W> c(nhashes, nbuckets, seed) ;
+  count_min_sketch c(nhashes, nbuckets, seed, allocator) ;
   const bool is_empty = (flags_byte & (1 << flags::IS_EMPTY)) > 0;
   if (is_empty == 1) return c ; // sketch is empty, no need to read further.
 
@@ -345,24 +356,23 @@ count_min_sketch<W> count_min_sketch<W>::deserialize(std::istream& is, uint64_t 
   return c ;
 }
 
-template<typename W>
-auto count_min_sketch<W>::serialize(unsigned header_size_bytes) const -> vector_bytes {
+template<typename W, typename A>
+size_t count_min_sketch<W,A>::get_serialized_size_bytes() const {
+  // The header is always 2 bytes, whether empty or full
+  size_t preamble_longs = PREAMBLE_LONGS_SHORT;
 
-  // The first 4 (of 8) bytes are either 1 or 0 (denoting empty vs non-empty) and the final 4 bytes are unused.
-  const uint8_t preamble_longs = is_empty() ? PREAMBLE_LONGS_SHORT : PREAMBLE_LONGS_FULL;
+  // If the sketch is empty, we're done. Otherwise, we need the total weight
+  // held by the sketch as well as a data table of size (num_buckets * num_hashes)
+  return preamble_longs + (is_empty() ? 0 : sizeof(W) * (1 + _num_buckets * _num_hashes));
+}
 
-  // Variable table bytes is used to determine how many bytes to allocate for the sketch table.
-  // We assume that 8 bytes are necessary per entry in the table.
-  // The extra 1 is for the total_weight variable which will be zero iff the sketch is empty.
-  // Hence, table_bytes == 0 iff sketch is empty <=> preamble_longs == 1
-  const size_t table_bytes(is_empty() ? 0 : (1 + _num_hashes) * _num_buckets);
-  const size_t size = header_size_bytes + sizeof(uint64_t) * (2 + table_bytes);
-  vector_bytes bytes(size, 0);
+template<typename W, typename A>
+auto count_min_sketch<W,A>::serialize(unsigned header_size_bytes) const -> vector_bytes {
+  vector_bytes bytes(header_size_bytes + get_serialized_size_bytes(), 0, _allocator);
   uint8_t *ptr = bytes.data() + header_size_bytes;
-  //std::cout<< "Preamble Long: " << preamble_longs << std::endl;
-  //std::cout<< "Writing " << size << " bytes." << std::endl;
 
   // Long 0
+  const uint8_t preamble_longs = PREAMBLE_LONGS_SHORT;
   ptr += copy_to_mem(preamble_longs, ptr);
   const uint8_t ser_ver = SERIAL_VERSION_1;
   ptr += copy_to_mem(ser_ver, ptr);
@@ -398,8 +408,8 @@ auto count_min_sketch<W>::serialize(unsigned header_size_bytes) const -> vector_
   return bytes;
 }
 
-template<typename W>
-count_min_sketch<W> count_min_sketch<W>::deserialize(const void* bytes, size_t size, uint64_t seed) {
+template<typename W, typename A>
+auto count_min_sketch<W,A>::deserialize(const void* bytes, size_t size, uint64_t seed, const A& allocator) -> count_min_sketch {
   const char* ptr = static_cast<const char*>(bytes);
 
   // First 8 bytes are 4 bytes of preamble and 4 unused bytes.
@@ -428,7 +438,7 @@ count_min_sketch<W> count_min_sketch<W>::deserialize(const void* bytes, size_t s
     throw std::invalid_argument("Incompatible seed hashes: " + std::to_string(seed_hash) + ", "
                                 + std::to_string(compute_seed_hash(seed)));
   }
-  count_min_sketch<W> c(nhashes, nbuckets, seed) ;
+  count_min_sketch c(nhashes, nbuckets, seed, allocator) ;
   const bool is_empty = (flags_byte & (1 << flags::IS_EMPTY)) > 0;
   if (is_empty) return c ; // sketch is empty, no need to read further.
 
@@ -444,13 +454,13 @@ count_min_sketch<W> count_min_sketch<W>::deserialize(const void* bytes, size_t s
   return c;
 }
 
-template<typename W>
-bool count_min_sketch<W>::is_empty() const {
+template<typename W, typename A>
+bool count_min_sketch<W,A>::is_empty() const {
   return _total_weight == 0;
 }
 
-template<typename W>
-string<std::allocator<W>> count_min_sketch<W>::to_string() const {
+template<typename W, typename A>
+string<A> count_min_sketch<W,A>::to_string() const {
   // count the number of used entries in the sketch
   uint64_t num_nonzero = 0;
   for (auto entry : _sketch_array) {
@@ -469,20 +479,20 @@ string<std::allocator<W>> count_min_sketch<W>::to_string() const {
   os << "   pct filled     : " << std::setprecision(3) << (num_nonzero * 100.0) / _sketch_array.size() << "%" << std::endl;
   os << "### End sketch summary" << std::endl;
 
-  //return string<A>(os.str().c_str(), allocator_);
-  return string<std::allocator<W>>(os.str().c_str());
+  return string<A>(os.str().c_str(), _allocator);
 }
 
-template<typename W>
-void count_min_sketch<W>::check_header_validity(uint8_t preamble_longs, uint8_t serial_version,  uint8_t family_id, uint8_t flags_byte) {
+template<typename W, typename A>
+void count_min_sketch<W,A>::check_header_validity(uint8_t preamble_longs, uint8_t serial_version,  uint8_t family_id, uint8_t flags_byte) {
   const bool empty = (flags_byte & (1 << flags::IS_EMPTY)) > 0;
 
   const uint8_t sw = (empty ? 1 : 0) + (2 * serial_version) + (4 * family_id) + (32 * (preamble_longs & 0x3F));
   bool valid = true;
 
   switch (sw) { // exhaustive list and description of all valid cases
+    case 70 : break; // !empty, ser_ver==1, family==1, preLongs=2;
     case 71 : break; // empty, ser_ver==1, family==1, preLongs=2;
-    case 102 : break ; // !empty, ser_ver==1, family==1, preLongs=3 ;
+    //case 102 : break ; // !empty, ser_ver==1, family==1, preLongs=3 ;
     default : // all other case values are invalid
       valid = false;
   }
@@ -490,13 +500,12 @@ void count_min_sketch<W>::check_header_validity(uint8_t preamble_longs, uint8_t 
   if (!valid) {
     std::ostringstream os;
     os << "Possible sketch corruption. Inconsistent state: "
-       << "preamble_longs = " << preamble_longs
+       << "preamble_longs = " << static_cast<uint32_t>(preamble_longs)
        << ", empty = " << (empty ? "true" : "false")
-       << ", serialization_version = " << serial_version ;
+       << ", serialization_version = " << static_cast<uint32_t>(serial_version) ;
     throw std::invalid_argument(os.str());
   }
 }
-
 
 } /* namespace datasketches */
 

--- a/count/test/CMakeLists.txt
+++ b/count/test/CMakeLists.txt
@@ -39,4 +39,5 @@ add_test(
 target_sources(count_min_test
         PRIVATE
         count_min_test.cpp
+        count_min_allocation_test.cpp
         )

--- a/count/test/count_min_allocation_test.cpp
+++ b/count/test/count_min_allocation_test.cpp
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <catch2/catch.hpp>
+#include <vector>
+#include <cstring>
+#include <sstream>
+#include <fstream>
+
+#include "count_min.hpp"
+#include "common_defs.hpp"
+#include "test_allocator.hpp"
+
+namespace datasketches {
+
+using count_min_sketch_test_alloc = count_min_sketch<uint64_t, test_allocator<uint64_t>>;
+using alloc = test_allocator<uint64_t>;
+
+TEST_CASE("CountMin sketch test allocator: serialize-deserialize empty", "[cm_sketch_alloc]"){
+  test_allocator_total_bytes = 0;
+  test_allocator_net_allocations = 0;
+  {
+    uint8_t n_hashes = 1 ;
+    uint32_t n_buckets = 5 ;
+    std::stringstream s(std::ios::in | std::ios::out | std::ios::binary);
+    count_min_sketch_test_alloc c(n_hashes, n_buckets, DEFAULT_SEED, alloc(0)) ;
+    c.serialize(s);
+    count_min_sketch_test_alloc d = count_min_sketch_test_alloc::deserialize(s, DEFAULT_SEED, alloc(0)) ;
+    REQUIRE(c.get_num_hashes() == d.get_num_hashes()) ;
+    REQUIRE(c.get_num_buckets() == d.get_num_buckets()) ;
+    REQUIRE(c.get_seed() == d.get_seed()) ;
+    uint64_t zero = 0;
+    REQUIRE(c.get_estimate(zero) == d.get_estimate(zero)) ;
+    REQUIRE(c.get_total_weight() == d.get_total_weight()) ;
+
+    // Check that all entries are equal and 0
+    for(auto di: d){
+      REQUIRE(di == 0) ;
+    }
+  }
+  REQUIRE(test_allocator_total_bytes == 0);
+  REQUIRE(test_allocator_net_allocations == 0);
+}
+
+TEST_CASE("CountMin sketch test allocator: serialize-deserialize non-empty", "[cm_sketch_alloc]"){
+  test_allocator_total_bytes = 0;
+  test_allocator_net_allocations = 0;
+  {
+    uint8_t n_hashes = 3 ;
+    uint32_t n_buckets = 1024 ;
+    std::stringstream s(std::ios::in | std::ios::out | std::ios::binary);
+    count_min_sketch_test_alloc c(n_hashes, n_buckets, DEFAULT_SEED, alloc(0)) ;
+    for(uint64_t i=0 ; i < 10; ++i) c.update(i,10*i*i) ;
+    c.serialize(s);
+    count_min_sketch_test_alloc d = count_min_sketch_test_alloc::deserialize(s, DEFAULT_SEED, alloc(0)) ;
+    REQUIRE(c.get_num_hashes() == d.get_num_hashes()) ;
+    REQUIRE(c.get_num_buckets() == d.get_num_buckets()) ;
+    REQUIRE(c.get_seed() == d.get_seed()) ;
+    REQUIRE(c.get_total_weight() == d.get_total_weight()) ;
+    for(uint64_t i=0 ; i < 10; ++i){
+      REQUIRE(c.get_estimate(i) == d.get_estimate(i)) ;
+    }
+
+    auto c_it = c.begin() ;
+    auto d_it = d.begin() ;
+    while(c_it != c.end()){
+      REQUIRE(*c_it == *d_it) ;
+      ++c_it ;
+      ++d_it ;
+    }
+  }
+  REQUIRE(test_allocator_total_bytes == 0);
+  REQUIRE(test_allocator_net_allocations == 0);
+}
+
+TEST_CASE("CountMin sketch test allocator: bytes serialize-deserialize empty", "[cm_sketch_alloc]"){
+  test_allocator_total_bytes = 0;
+  test_allocator_net_allocations = 0;
+  {
+    uint8_t n_hashes = 3 ;
+    uint32_t n_buckets = 32 ;
+    count_min_sketch_test_alloc c(n_hashes, n_buckets, DEFAULT_SEED, alloc(0)) ;
+    auto bytes = c.serialize() ;
+
+    REQUIRE_THROWS_AS(count_min_sketch_test_alloc::deserialize(bytes.data(), bytes.size(), DEFAULT_SEED-1, alloc(0)), std::invalid_argument);
+    auto d = count_min_sketch_test_alloc::deserialize(bytes.data(), bytes.size(), DEFAULT_SEED, alloc(0)) ;
+    REQUIRE(c.get_num_hashes() == d.get_num_hashes()) ;
+    REQUIRE(c.get_num_buckets() == d.get_num_buckets()) ;
+    REQUIRE(c.get_seed() == d.get_seed()) ;
+    uint64_t zero = 0;
+    REQUIRE(c.get_estimate(zero) == d.get_estimate(zero)) ;
+    REQUIRE(c.get_total_weight() == d.get_total_weight()) ;
+
+    // Check that all entries are equal and 0
+    for(auto di: d){
+      REQUIRE(di == 0) ;
+    }
+  }
+  REQUIRE(test_allocator_total_bytes == 0);
+  REQUIRE(test_allocator_net_allocations == 0);
+}
+
+TEST_CASE("CountMin sketch test allocator: bytes serialize-deserialize non-empty", "[cm_sketch_alloc]"){
+  test_allocator_total_bytes = 0;
+  test_allocator_net_allocations = 0;
+  {
+    uint8_t n_hashes = 5 ;
+    uint32_t n_buckets = 64 ;
+    count_min_sketch_test_alloc c(n_hashes, n_buckets, DEFAULT_SEED, alloc(0)) ;
+    for(uint64_t i=0 ; i < 10; ++i) c.update(i,10*i*i) ;
+
+    auto bytes = c.serialize() ;
+    REQUIRE_THROWS_AS(count_min_sketch_test_alloc::deserialize(bytes.data(), bytes.size(), DEFAULT_SEED-1, alloc(0)), std::invalid_argument);
+    auto d = count_min_sketch_test_alloc::deserialize(bytes.data(), bytes.size(), DEFAULT_SEED, alloc(0)) ;
+
+    REQUIRE(c.get_num_hashes() == d.get_num_hashes()) ;
+    REQUIRE(c.get_num_buckets() == d.get_num_buckets()) ;
+    REQUIRE(c.get_seed() == d.get_seed()) ;
+    REQUIRE(c.get_total_weight() == d.get_total_weight()) ;
+
+    // Check that all entries are equal
+    auto c_it = c.begin() ;
+    auto d_it = d.begin() ;
+    while(c_it != c.end()){
+      REQUIRE(*c_it == *d_it) ;
+      ++c_it ;
+      ++d_it ;
+    }
+
+    // Check that the estimates agree
+    for(uint64_t i=0 ; i < 10; ++i){
+      REQUIRE(c.get_estimate(i) == d.get_estimate(i)) ;
+    }
+  }
+  REQUIRE(test_allocator_total_bytes == 0);
+  REQUIRE(test_allocator_net_allocations == 0);
+}
+
+} // namespace datasketches

--- a/count/test/count_min_test.cpp
+++ b/count/test/count_min_test.cpp
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 #include <catch2/catch.hpp>
 #include <vector>
 #include <cstring>
@@ -190,7 +209,8 @@ TEST_CASE("CountMin sketch: serialize-deserialize empty", "[cm_sketch]"){
     REQUIRE(c.get_num_hashes() == d.get_num_hashes()) ;
     REQUIRE(c.get_num_buckets() == d.get_num_buckets()) ;
     REQUIRE(c.get_seed() == d.get_seed()) ;
-    REQUIRE(c.get_estimate(0) == d.get_estimate(0)) ;
+    uint64_t zero = 0;
+    REQUIRE(c.get_estimate(zero) == d.get_estimate(zero)) ;
     REQUIRE(c.get_total_weight() == d.get_total_weight()) ;
 
     // Check that all entries are equal and 0
@@ -240,7 +260,8 @@ TEST_CASE("CountMin sketch: bytes serialize-deserialize empty", "[cm_sketch]"){
   REQUIRE(c.get_num_hashes() == d.get_num_hashes()) ;
   REQUIRE(c.get_num_buckets() == d.get_num_buckets()) ;
   REQUIRE(c.get_seed() == d.get_seed()) ;
-  REQUIRE(c.get_estimate(0) == d.get_estimate(0)) ;
+  uint64_t zero = 0;
+  REQUIRE(c.get_estimate(zero) == d.get_estimate(zero)) ;
   REQUIRE(c.get_total_weight() == d.get_total_weight()) ;
 
   // Check that all entries are equal and 0
@@ -280,7 +301,6 @@ TEST_CASE("CountMin sketch: bytes serialize-deserialize non-empty", "[cm_sketch]
   }
 
 }
-
 
 } /* namespace datasketches */
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(python
     sampling
     req
     quantiles
+    count
     pybind11::module
 )
 
@@ -76,6 +77,7 @@ target_sources(python
     src/req_wrapper.cpp
     src/quantiles_wrapper.cpp
     src/ks_wrapper.cpp
+    src/count_wrapper.cpp
     src/vector_of_kll.cpp
     src/py_serde.cpp
 )

--- a/python/src/count_wrapper.cpp
+++ b/python/src/count_wrapper.cpp
@@ -59,9 +59,9 @@ void bind_count_min_sketch(py::module &m, const char* name) {
          "Returns the maximum permissible error for any frequency estimate query")
     .def("get_total_weight", &count_min_sketch<W>::get_total_weight,
          "Returns the total weight currently inserted into the stream")
-    .def("update", static_cast<void (count_min_sketch<W>::*)(int64_t)>(&count_min_sketch<W>::update), py::arg("item"),
+    .def("update", static_cast<void (count_min_sketch<W>::*)(int64_t, W)>(&count_min_sketch<W>::update), py::arg("item"), py::arg("weight")=1.0,
          "Updates the sketch with the given 64-bit integer value")
-    .def("update", static_cast<void (count_min_sketch<W>::*)(const std::string&)>(&count_min_sketch<W>::update), py::arg("item"),
+    .def("update", static_cast<void (count_min_sketch<W>::*)(const std::string&, W)>(&count_min_sketch<W>::update), py::arg("item"), py::arg("weight")=1.0,
          "Updates the sketch with the given string")
     .def("get_estimate", static_cast<W (count_min_sketch<W>::*)(int64_t) const>(&count_min_sketch<W>::get_estimate), py::arg("item"),
          "Returns an estimate of the frequency of the provided 64-bit integer value")

--- a/python/src/count_wrapper.cpp
+++ b/python/src/count_wrapper.cpp
@@ -77,6 +77,8 @@ void bind_count_min_sketch(py::module &m, const char* name) {
          "Returns an lower bound on the estimate for the provided string")
     .def("merge", &count_min_sketch<W>::merge, py::arg("other"),
          "Merges the provided other sketch into this one")
+    .def("get_serialized_size_bytes", &count_min_sketch<W>::get_serialized_size_bytes,
+         "Returns the size in bytes of the serialized image of the sketch")
     .def(
         "serialize",
         [](const count_min_sketch<W>& sk) {

--- a/python/src/count_wrapper.cpp
+++ b/python/src/count_wrapper.cpp
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <pybind11/pybind11.h>
+
+#include "count_min.hpp"
+#include "common_defs.hpp"
+
+namespace py = pybind11;
+
+template<typename W>
+void bind_count_min_sketch(py::module &m, const char* name) {
+  using namespace datasketches;
+
+  py::class_<count_min_sketch<W>>(m, name)
+    .def(py::init<uint8_t, uint32_t, uint64_t>(), py::arg("num_hashes"), py::arg("num_buckets"), py::arg("seed")=DEFAULT_SEED)
+    .def(py::init<const count_min_sketch<W>&>())
+    .def_static("suggest_num_buckets", &count_min_sketch<W>::suggest_num_buckets, py::arg("relative_error"),
+                "Suggests the number of buckets needed to achieve an accuracy within the provided "
+                "relative_error. For example, when relative_error = 0.05, the returned frequency estimates "
+                "satisfy the 'relative_error' guarantee that never overestimates the weights by may "
+                "underestimate hte weights by 5% of the total weight in the sketch. "
+                "Returns the number of hash buckets at every level of the sketch required in order to obtain "
+                "the specified relative error.")
+    .def_static("suggest_num_hashes", &count_min_sketch<W>::suggest_num_hashes, py::arg("confidence"),
+                "Suggests the number of hashes needed to achieve the provided confidence. For example, "
+                "with 95% confidence, frequency estimates satisfy the 'relative_error' guarantee. "
+                "Returns the number of hash functions that are required in order to achieve the specified "
+                "confidence of the sketch. confidence = 1 - delta, with delta denoting the sketch failure probability.")
+    .def("__str__", &count_min_sketch<W>::to_string,
+         "Produces a string summary of the sketch")
+    .def("to_string", &count_min_sketch<W>::to_string,
+         "Produces a string summary of the sketch")
+    .def("is_empty", &count_min_sketch<W>::is_empty,
+         "Returns True if the sketch has seen no items, otherwise False")
+    .def("get_num_hashes", &count_min_sketch<W>::get_num_hashes,
+         "Returns the configured number of hashes for the sketch")
+    .def("get_num_buckets", &count_min_sketch<W>::get_num_buckets,
+         "Returns the configured number of buckets for the sketch")
+    .def("get_seed", &count_min_sketch<W>::get_seed,
+         "Returns the base hash seed for the sketch")
+    .def("get_relative_error", &count_min_sketch<W>::get_relative_error,
+         "Returns the maximum permissible error for any frequency estimate query")
+    .def("get_total_weight", &count_min_sketch<W>::get_total_weight,
+         "Returns the total weight currently inserted into the stream")
+    .def("update", static_cast<void (count_min_sketch<W>::*)(int64_t)>(&count_min_sketch<W>::update), py::arg("item"),
+         "Updates the sketch with the given 64-bit integer value")
+    .def("update", static_cast<void (count_min_sketch<W>::*)(const std::string&)>(&count_min_sketch<W>::update), py::arg("item"),
+         "Updates the sketch with the given string")
+    .def("get_estimate", static_cast<W (count_min_sketch<W>::*)(int64_t) const>(&count_min_sketch<W>::get_estimate), py::arg("item"),
+         "Returns an estimate of the frequency of the provided 64-bit integer value")
+    .def("get_estimate", static_cast<W (count_min_sketch<W>::*)(const std::string&) const>(&count_min_sketch<W>::get_estimate), py::arg("item"),
+         "Returns an estimate of the frequency of the provided string")
+    .def("get_upper_bound", static_cast<W (count_min_sketch<W>::*)(int64_t) const>(&count_min_sketch<W>::get_upper_bound), py::arg("item"),
+         "Returns an upper bound on the estimate for the given 64-bit integer value")
+    .def("get_upper_bound", static_cast<W (count_min_sketch<W>::*)(const std::string&) const>(&count_min_sketch<W>::get_upper_bound), py::arg("item"),
+         "Returns an upper bound on the estimate for the provided string")
+    .def("get_lower_bound", static_cast<W (count_min_sketch<W>::*)(int64_t) const>(&count_min_sketch<W>::get_lower_bound), py::arg("item"),
+         "Returns an lower bound on the estimate for the given 64-bit integer value")
+    .def("get_lower_bound", static_cast<W (count_min_sketch<W>::*)(const std::string&) const>(&count_min_sketch<W>::get_lower_bound), py::arg("item"),
+         "Returns an lower bound on the estimate for the provided string")
+    .def("merge", &count_min_sketch<W>::merge, py::arg("other"),
+         "Merges the provided other sketch into this one")
+    .def(
+        "serialize",
+        [](const count_min_sketch<W>& sk) {
+          auto bytes = sk.serialize();
+          return py::bytes(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+        },
+        "Serializes the sketch into a bytes object"
+    )
+    .def_static(
+        "deserialize",
+        [](const std::string& bytes) { return count_min_sketch<W>::deserialize(bytes.data(), bytes.size()); },
+        py::arg("bytes"),
+        "Reads a bytes object and returns the corresponding count_min_sketch"
+    );
+}
+
+void init_count_min(py::module &m) {
+  bind_count_min_sketch<double>(m, "count_min_sketch");
+}
+

--- a/python/src/datasketches.cpp
+++ b/python/src/datasketches.cpp
@@ -30,6 +30,7 @@ void init_theta(py::module& m);
 void init_vo(py::module& m);
 void init_req(py::module& m);
 void init_quantiles(py::module& m);
+void init_count_min(py::module& m);
 void init_vector_of_kll(py::module& m);
 
 // supporting objects
@@ -45,6 +46,7 @@ PYBIND11_MODULE(_datasketches, m) {
   init_vo(m);
   init_req(m);
   init_quantiles(m);
+  init_count_min(m);
   init_vector_of_kll(m);
 
   init_kolmogorov_smirnov(m);

--- a/python/tests/count_min_test.py
+++ b/python/tests/count_min_test.py
@@ -1,0 +1,85 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+  
+import unittest
+from datasketches import count_min_sketch
+
+class CountMinTest(unittest.TestCase):
+  def test_count_min_example(self):
+    # we'll define target confidence and relative error and use the built-in
+    # methods to determine how many hashes and buckets to use
+    confidence = 0.95
+    num_hashes = count_min_sketch.suggest_num_hashes(confidence)
+    relative_error = 0.01
+    num_buckets = count_min_sketch.suggest_num_buckets(relative_error)
+
+    # now we can create a few empty sketches
+    cm = count_min_sketch(num_hashes, num_buckets)
+    cm2 = count_min_sketch(num_hashes, num_buckets)
+    self.assertTrue(cm.is_empty())
+
+    # we'll use a moderate number of distinct items with
+    # increasing weights, with each item's weight being
+    # equal to its value
+    n = 1000
+    total_wt = 0
+    for i in range(1, n+1):
+      cm.update(i, i)
+      total_wt += i
+    self.assertFalse(cm.is_empty())
+    self.assertEqual(cm.get_total_weight(), total_wt)
+
+    # querying the items, each of them should
+    # have a non-zero count.  the estimate should
+    # be at least i with appropriately behaved bounds.
+    for i in range(1, n+1):
+      val = cm.get_estimate(i)
+      self.assertGreaterEqual(val, i)
+      self.assertGreaterEqual(val, cm.get_lower_bound(i))
+      self.assertGreater(cm.get_upper_bound(i), val)
+
+    # values not in the sketch should have lower estimates, but
+    # are not guaranteed to be zero and will succeed
+    self.assertIsNotNone(cm.get_estimate("not in set"))
+
+    # we can create another sketch with partial overlap
+    # and merge them
+    for i in range(int(n / 2), int(3 * n / 2)):
+      cm2.update(i, i)
+    cm.merge(cm2)
+
+    # and the estimated weight for the meerged values should now be
+    # at least 2x the value
+    self.assertGreaterEqual(cm.get_estimate(n), 2 * n)
+
+    # finally, serialize and reconstruct
+    cm_bytes = cm.serialize()
+    new_cm = count_min_sketch.deserialize(cm_bytes)
+
+    # and now interrogate the sketch
+    self.assertFalse(new_cm.is_empty())
+    self.assertEqual(new_cm.get_num_hashes(), cm.get_num_hashes())
+    self.assertEqual(new_cm.get_num_buckets(), cm.get_num_buckets())
+    self.assertEqual(new_cm.get_total_weight(), cm.get_total_weight())
+    
+    # we can also iterate through values in and out of the sketch to ensure
+    # the estimates match
+    for i in range(0, 2 * n):
+      self.assertEqual(cm.get_estimate(i), new_cm.get_estimate(i))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/tests/count_min_test.py
+++ b/python/tests/count_min_test.py
@@ -68,6 +68,7 @@ class CountMinTest(unittest.TestCase):
 
     # finally, serialize and reconstruct
     cm_bytes = cm.serialize()
+    self.assertEqual(cm.get_serialized_size_bytes(), len(cm_bytes))
     new_cm = count_min_sketch.deserialize(cm_bytes)
 
     # and now interrogate the sketch


### PR DESCRIPTION
Adds python support for count_min, using double -- thinking maybe it should be int64_t weights by default instead? Or maybe unsigned if deletions aren't a thing?