### PR TITLE
Hll delay kxq

### DIFF
--- a/hll/include/Hll4Array-internal.hpp
+++ b/hll/include/Hll4Array-internal.hpp
@@ -60,7 +60,7 @@ Hll4Array<A>::Hll4Array(const HllArray<A>& other) :
   this->hllByteArr_.resize(numBytes, 0);
   this->oooFlag_ = other.isOutOfOrderFlag();
 
-  for (const auto& coupon : other) { // all = false, so skip empty values
+  for (const auto coupon : other) { // all = false, so skip empty values
     internalCouponUpdate(coupon); // updates KxQ registers
   }
   this->hipAccum_ = other.getHipAccum();

--- a/hll/include/Hll4Array.hpp
+++ b/hll/include/Hll4Array.hpp
@@ -30,6 +30,7 @@ class Hll4Array final : public HllArray<A> {
   public:
     explicit Hll4Array(uint8_t lgConfigK, bool startFullSize, const A& allocator);
     explicit Hll4Array(const Hll4Array<A>& that);
+    explicit Hll4Array(const HllArray<A>& that);
 
     virtual ~Hll4Array();
     virtual std::function<void(HllSketchImpl<A>*)> get_deleter() const;
@@ -44,7 +45,6 @@ class Hll4Array final : public HllArray<A> {
     virtual uint32_t getHllByteArrBytes() const;
 
     virtual HllSketchImpl<A>* couponUpdate(uint32_t coupon) final;
-    void mergeHll(const HllArray<A>& src);
 
     virtual AuxHashMap<A>* getAuxHashMap() const;
     // does *not* delete old map if overwriting

--- a/hll/include/Hll6Array-internal.hpp
+++ b/hll/include/Hll6Array-internal.hpp
@@ -43,7 +43,7 @@ Hll6Array<A>::Hll6Array(const HllArray<A>& other) :
   this->oooFlag_ = other.isOutOfOrderFlag();
   uint32_t num_zeros = 1 << this->lgConfigK_;
   
-  for (const auto& coupon : other) { // all = false, so skip empty values
+  for (const auto coupon : other) { // all = false, so skip empty values
     num_zeros--;
     internalCouponUpdate(coupon); // updates KxQ registers
   }

--- a/hll/include/Hll6Array.hpp
+++ b/hll/include/Hll6Array.hpp
@@ -31,6 +31,7 @@ template<typename A>
 class Hll6Array final : public HllArray<A> {
   public:
     Hll6Array(uint8_t lgConfigK, bool startFullSize, const A& allocator);
+    explicit Hll6Array(const HllArray<A>& that);
 
     virtual ~Hll6Array() = default;
     virtual std::function<void(HllSketchImpl<A>*)> get_deleter() const;
@@ -41,7 +42,6 @@ class Hll6Array final : public HllArray<A> {
     inline void putSlot(uint32_t slotNo, uint8_t value);
 
     virtual HllSketchImpl<A>* couponUpdate(uint32_t coupon) final;
-    void mergeHll(const HllArray<A>& src);
 
     virtual uint32_t getHllByteArrBytes() const;
 

--- a/hll/include/Hll8Array-internal.hpp
+++ b/hll/include/Hll8Array-internal.hpp
@@ -41,7 +41,7 @@ Hll8Array<A>::Hll8Array(const HllArray<A>& other):
   this->oooFlag_ = other.isOutOfOrderFlag();
   uint32_t num_zeros = 1 << this->lgConfigK_;
   
-  for (const auto& coupon : other) { // all = false, so skip empty values
+  for (const auto coupon : other) { // all = false, so skip empty values
     num_zeros--;
     internalCouponUpdate(coupon); // updates KxQ registers
   }
@@ -114,37 +114,78 @@ void Hll8Array<A>::mergeList(const CouponList<A>& src) {
 template<typename A>
 void Hll8Array<A>::mergeHll(const HllArray<A>& src) {
   // at this point src_k >= dst_k
-  const uint32_t dst_mask = (1 << this->getLgConfigK()) - 1;
-  // special treatment below to optimize performance
-  if (src.getTgtHllType() == target_hll_type::HLL_8) {
-    uint32_t i = 0;
-    for (const auto value: src.getHllArray()) {
-      processValue(i++, dst_mask, value);
+  // we can optimize further when the k values are equal
+  if (this->getLgConfigK() == src.getLgConfigK()) {
+    if (src.getTgtHllType() == target_hll_type::HLL_8) {
+      uint32_t i = 0;
+      for (const auto value: src.getHllArray()) {
+        this->hllByteArr_[i] = std::max(this->hllByteArr_[i], value);
+        ++i;
+      }
+    } else if (src.getTgtHllType() == target_hll_type::HLL_6) {
+      const uint32_t src_k = 1 << src.getLgConfigK();
+      uint32_t i = 0;
+      const uint8_t* ptr = src.getHllArray().data();
+      while (i < src_k) {
+        uint8_t value = *ptr & 0x3f;
+        this->hllByteArr_[i] = std::max(this->hllByteArr_[i], value);
+        ++i;
+        value = *ptr++ >> 6;
+        value |= (*ptr & 0x0f) << 2;
+        this->hllByteArr_[i] = std::max(this->hllByteArr_[i], value);
+        ++i;
+        value = *ptr++ >> 4;
+        value |= (*ptr & 3) << 4;
+        this->hllByteArr_[i] = std::max(this->hllByteArr_[i], value);
+        ++i;
+        value = *ptr++ >> 2;
+        this->hllByteArr_[i] = std::max(this->hllByteArr_[i], value);
+        ++i;
+      }
+    } else { // HLL_4
+      const auto& src4 = static_cast<const Hll4Array<A>&>(src);
+      uint32_t i = 0;
+      for (const auto byte: src.getHllArray()) {
+        this->hllByteArr_[i] = std::max(this->hllByteArr_[i], src4.adjustRawValue(i, byte & hll_constants::loNibbleMask));
+        ++i;
+        this->hllByteArr_[i] = std::max(this->hllByteArr_[i], src4.adjustRawValue(i, byte >> 4));
+        ++i;
+      }
     }
-  } else if (src.getTgtHllType() == target_hll_type::HLL_6) {
-    const uint32_t src_k = 1 << src.getLgConfigK();
-    uint32_t i = 0;
-    const uint8_t* ptr = src.getHllArray().data();
-    while (i < src_k) {
-      uint8_t value = *ptr & 0x3f;
-      processValue(i++, dst_mask, value);
-      value = *ptr++ >> 6;
-      value |= (*ptr & 0x0f) << 2;
-      processValue(i++, dst_mask, value);
-      value = *ptr++ >> 4;
-      value |= (*ptr & 3) << 4;
-      processValue(i++, dst_mask, value);
-      value = *ptr++ >> 2;
-      processValue(i++, dst_mask, value);
-    }
-  } else { // HLL_4
-    const auto& src4 = static_cast<const Hll4Array<A>&>(src);
-    uint32_t i = 0;
-    for (const auto byte: src.getHllArray()) {
-      processValue(i, dst_mask, src4.adjustRawValue(i, byte & hll_constants::loNibbleMask));
-      ++i;
-      processValue(i, dst_mask, src4.adjustRawValue(i, byte >> 4));
-      ++i;
+  } else {
+    // src_k > dst_k
+    const uint32_t dst_mask = (1 << this->getLgConfigK()) - 1;
+    // special treatment below to optimize performance
+    if (src.getTgtHllType() == target_hll_type::HLL_8) {
+      uint32_t i = 0;
+      for (const auto value: src.getHllArray()) {
+        processValue(i++, dst_mask, value);
+      }
+    } else if (src.getTgtHllType() == target_hll_type::HLL_6) {
+      const uint32_t src_k = 1 << src.getLgConfigK();
+      uint32_t i = 0;
+      const uint8_t* ptr = src.getHllArray().data();
+      while (i < src_k) {
+        uint8_t value = *ptr & 0x3f;
+        processValue(i++, dst_mask, value);
+        value = *ptr++ >> 6;
+        value |= (*ptr & 0x0f) << 2;
+        processValue(i++, dst_mask, value);
+        value = *ptr++ >> 4;
+        value |= (*ptr & 3) << 4;
+        processValue(i++, dst_mask, value);
+        value = *ptr++ >> 2;
+        processValue(i++, dst_mask, value);
+      }
+    } else { // HLL_4
+      const auto& src4 = static_cast<const Hll4Array<A>&>(src);
+      uint32_t i = 0;
+      for (const auto byte: src.getHllArray()) {
+        processValue(i, dst_mask, src4.adjustRawValue(i, byte & hll_constants::loNibbleMask));
+        ++i;
+        processValue(i, dst_mask, src4.adjustRawValue(i, byte >> 4));
+        ++i;
+      }
     }
   }
   this->setRebuildKxqCurminFlag(true);

--- a/hll/include/Hll8Array.hpp
+++ b/hll/include/Hll8Array.hpp
@@ -31,6 +31,7 @@ template<typename A>
 class Hll8Array final : public HllArray<A> {
   public:
     Hll8Array(uint8_t lgConfigK, bool startFullSize, const A& allocator);
+    explicit Hll8Array(const HllArray<A>& that);
 
     virtual ~Hll8Array() = default;
     virtual std::function<void(HllSketchImpl<A>*)> get_deleter() const;

--- a/hll/include/HllArray-internal.hpp
+++ b/hll/include/HllArray-internal.hpp
@@ -79,6 +79,8 @@ HllArray<A>* HllArray<A>::copyAs(target_hll_type tgtHllType) const {
       return HllSketchImplFactory<A>::convertToHll6(*this);
     case target_hll_type::HLL_8:
       return HllSketchImplFactory<A>::convertToHll8(*this);
+    default:
+      throw std::invalid_argument("Invalid target HLL type"); 
   }
 }
 

--- a/hll/include/HllArray.hpp
+++ b/hll/include/HllArray.hpp
@@ -32,6 +32,7 @@ template<typename A>
 class HllArray : public HllSketchImpl<A> {
   public:
     HllArray(uint8_t lgConfigK, target_hll_type tgtHllType, bool startFullSize, const A& allocator);
+    explicit HllArray(const HllArray& other, target_hll_type tgtHllType);
 
     static HllArray* newHll(const void* bytes, size_t len, const A& allocator);
     static HllArray* newHll(std::istream& is, const A& allocator);
@@ -86,6 +87,9 @@ class HllArray : public HllSketchImpl<A> {
 
     virtual AuxHashMap<A>* getAuxHashMap() const;
 
+    virtual void setRebuildKxqCurminFlag(bool rebuild);
+    virtual bool isRebuildKxqCurminFlag() const;
+
     class const_iterator;
     virtual const_iterator begin(bool all = false) const;
     virtual const_iterator end() const;
@@ -106,6 +110,7 @@ class HllArray : public HllSketchImpl<A> {
     uint8_t curMin_; //always zero for Hll6 and Hll8, only tracked by Hll4Array
     uint32_t numAtCurMin_; //interpreted as num zeros when curMin == 0
     bool oooFlag_; //Out-Of-Order Flag
+    bool rebuild_kxq_curmin_; // flag to recompute
 
     friend class HllSketchImplFactory<A>;
 };

--- a/hll/include/HllArray.hpp
+++ b/hll/include/HllArray.hpp
@@ -87,8 +87,9 @@ class HllArray : public HllSketchImpl<A> {
 
     virtual AuxHashMap<A>* getAuxHashMap() const;
 
-    virtual void setRebuildKxqCurminFlag(bool rebuild);
-    virtual bool isRebuildKxqCurminFlag() const;
+    void setRebuildKxqCurminFlag(bool rebuild);
+    bool isRebuildKxqCurminFlag() const;
+    void check_rebuild_kxq_cur_min();
 
     class const_iterator;
     virtual const_iterator begin(bool all = false) const;

--- a/hll/include/HllSketchImplFactory.hpp
+++ b/hll/include/HllSketchImplFactory.hpp
@@ -136,38 +136,20 @@ HllSketchImpl<A>* HllSketchImplFactory<A>::reset(HllSketchImpl<A>* impl, bool st
 
 template<typename A>
 Hll4Array<A>* HllSketchImplFactory<A>::convertToHll4(const HllArray<A>& srcHllArr) {
-  const uint8_t lgConfigK = srcHllArr.getLgConfigK();
   using Hll4Alloc = typename std::allocator_traits<A>::template rebind_alloc<Hll4Array<A>>;
-  Hll4Array<A>* hll4Array = new (Hll4Alloc(srcHllArr.getAllocator()).allocate(1))
-      Hll4Array<A>(lgConfigK, srcHllArr.isStartFullSize(), srcHllArr.getAllocator());
-  hll4Array->putOutOfOrderFlag(srcHllArr.isOutOfOrderFlag());
-  hll4Array->mergeHll(srcHllArr);
-  hll4Array->putHipAccum(srcHllArr.getHipAccum());
-  return hll4Array;
+  return new (Hll4Alloc(srcHllArr.getAllocator()).allocate(1)) Hll4Array<A>(srcHllArr);
 }
 
 template<typename A>
 Hll6Array<A>* HllSketchImplFactory<A>::convertToHll6(const HllArray<A>& srcHllArr) {
-  const uint8_t lgConfigK = srcHllArr.getLgConfigK();
   using Hll6Alloc = typename std::allocator_traits<A>::template rebind_alloc<Hll6Array<A>>;
-  Hll6Array<A>* hll6Array = new (Hll6Alloc(srcHllArr.getAllocator()).allocate(1))
-      Hll6Array<A>(lgConfigK, srcHllArr.isStartFullSize(), srcHllArr.getAllocator());
-  hll6Array->putOutOfOrderFlag(srcHllArr.isOutOfOrderFlag());
-  hll6Array->mergeHll(srcHllArr);
-  hll6Array->putHipAccum(srcHllArr.getHipAccum());
-  return hll6Array;
+  return new (Hll6Alloc(srcHllArr.getAllocator()).allocate(1)) Hll6Array<A>(srcHllArr);
 }
 
 template<typename A>
 Hll8Array<A>* HllSketchImplFactory<A>::convertToHll8(const HllArray<A>& srcHllArr) {
-  const uint8_t lgConfigK = srcHllArr.getLgConfigK();
   using Hll8Alloc = typename std::allocator_traits<A>::template rebind_alloc<Hll8Array<A>>;
-  Hll8Array<A>* hll8Array = new (Hll8Alloc(srcHllArr.getAllocator()).allocate(1))
-      Hll8Array<A>(lgConfigK, srcHllArr.isStartFullSize(), srcHllArr.getAllocator());
-  hll8Array->putOutOfOrderFlag(srcHllArr.isOutOfOrderFlag());
-  hll8Array->mergeHll(srcHllArr);
-  hll8Array->putHipAccum(srcHllArr.getHipAccum());
-  return hll8Array;
+  return new (Hll8Alloc(srcHllArr.getAllocator()).allocate(1)) Hll8Array<A>(srcHllArr);
 }
 
 }

--- a/hll/include/HllUnion-internal.hpp
+++ b/hll/include/HllUnion-internal.hpp
@@ -131,21 +131,29 @@ void hll_union_alloc<A>::coupon_update(uint32_t coupon) {
 
 template<typename A>
 double hll_union_alloc<A>::get_estimate() const {
+  if (gadget_.sketch_impl->getCurMode() == hll_mode::HLL)
+    static_cast<HllArray<A>*>(gadget_.sketch_impl)->check_rebuild_kxq_cur_min();
   return gadget_.get_estimate();
 }
 
 template<typename A>
 double hll_union_alloc<A>::get_composite_estimate() const {
+  if (gadget_.sketch_impl->getCurMode() == hll_mode::HLL)
+    static_cast<HllArray<A>*>(gadget_.sketch_impl)->check_rebuild_kxq_cur_min();
   return gadget_.get_composite_estimate();
 }
 
 template<typename A>
 double hll_union_alloc<A>::get_lower_bound(uint8_t num_std_dev) const {
+  if (gadget_.sketch_impl->getCurMode() == hll_mode::HLL)
+    static_cast<HllArray<A>*>(gadget_.sketch_impl)->check_rebuild_kxq_cur_min();
   return gadget_.get_lower_bound(num_std_dev);
 }
 
 template<typename A>
 double hll_union_alloc<A>::get_upper_bound(uint8_t num_std_dev) const {
+  if (gadget_.sketch_impl->getCurMode() == hll_mode::HLL)
+    static_cast<HllArray<A>*>(gadget_.sketch_impl)->check_rebuild_kxq_cur_min();
   return gadget_.get_upper_bound(num_std_dev);
 }
 

--- a/hll/test/HllUnionTest.cpp
+++ b/hll/test/HllUnionTest.cpp
@@ -53,10 +53,15 @@ static void basicUnion(uint64_t n1, uint64_t n2,
   v += n2;
 
   hll_union u(lgMaxK);
-  u.update(std::move(h1));
+  u.update(h1);
   u.update(h2);
 
   hll_sketch result = u.get_result(resultType);
+
+  // ensure we check a direct union estimate, without first caling get_result()
+  u.reset();
+  u.update(std::move(h1));
+  u.update(h2);
 
   // force non-HIP estimates to avoid issues with in- vs out-of-order
   double uEst = result.get_composite_estimate();
@@ -74,6 +79,7 @@ static void basicUnion(uint64_t n1, uint64_t n2,
   REQUIRE((uEst - uLb) >= 0.0);
 
   REQUIRE(controlEst == uEst);
+  REQUIRE(controlEst == u.get_composite_estimate());
 }
 
 /**


### PR DESCRIPTION
This changes HLL union to delay recomputing the KxQ and cur_min values until the union gadget needs to be made a consistent sketch (either get_result() or a direct get_estimate() will trigger that). This mirrors how HLL union operates in java.

Using characterization's hll-union-timing test on my linux desktop showed a steady-state merge speed improvement around 2.8x.