### PR TITLE
Added get_lg_k to cpc's python wrapper

### DIFF
--- a/python/src/cpc_wrapper.cpp
+++ b/python/src/cpc_wrapper.cpp
@@ -42,6 +42,8 @@ void init_cpc(py::module &m) {
          "Updates the sketch with the given 64-bit floating point")
     .def<void (cpc_sketch::*)(const std::string&)>("update", &cpc_sketch::update, py::arg("datum"),
          "Updates the sketch with the given string")
+    .def("get_lg_k", &cpc_sketch::get_lg_k,
+         "Returns configured lg_k of this sketch")
     .def("is_empty", &cpc_sketch::is_empty,
          "Returns True if the sketch is empty, otherwise False")
     .def("get_estimate", &cpc_sketch::get_estimate,

--- a/python/tests/cpc_test.py
+++ b/python/tests/cpc_test.py
@@ -60,5 +60,10 @@ class CpcTest(unittest.TestCase):
     new_cpc = cpc_sketch.deserialize(sk_bytes)
     self.assertFalse(new_cpc.is_empty())
 
+  def test_cpc_get_lg_k(self):
+    lgk = 10
+    cpc = cpc_sketch(lgk)
+    self.assertEqual(cpc.get_lg_k(), lgk)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
We're using the CPC module from Python, and it's convenient to be able to call `get_lg_k` to see with what parameter a sketch was configured with. This PR exposes it via Python bindings. 