### PR TITLE
avoid marketplace action

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -12,11 +12,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Install doxygen
+        run: sudo apt install doxygen -y
       - name: Run Doxygen
-        uses: mattnotmitt/doxygen-action@v1.9.5
-        with:
-          doxyfile-path: ./Doxyfile
-          working-directory: .
+        run: doxygen Doxyfile
       - name: Pages Deployment
         uses: peaceiris/actions-gh-pages@v3.9.3
         with:


### PR DESCRIPTION
Replaced the first marketplace doxygen action with simple commands.
The second marketplace action is still there.
Let's see if it works.