### PR TITLE
fix install file list for array of doubles

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -45,8 +45,10 @@ jobs:
           submodules: true
           persist-credentials: false
       - name: Configure
-        run: cd build && cmake ..
+        run: cmake -B build -S . -DCMAKE_INSTALL_PREFIX=./install_test
       - name: Build C++ unit tests
         run: cmake --build build --config Release
       - name: Run C++ tests
         run: cmake --build build --config Release --target ${{ matrix.config.test_target }}
+      - name: Install headers
+        run: cmake --build build -t install

--- a/tuple/CMakeLists.txt
+++ b/tuple/CMakeLists.txt
@@ -47,11 +47,12 @@ install(FILES
 		include/tuple_a_not_b_impl.hpp
 		include/tuple_jaccard_similarity.hpp
 		include/array_of_doubles_sketch.hpp
-		include/array_of_doubles_sketch_impl.hpp
-		include/array_of_doubles_union.hpp
-		include/array_of_doubles_union_impl.hpp
-		include/array_of_doubles_intersection.hpp
-		include/array_of_doubles_intersection_impl.hpp
-		include/array_of_doubles_a_not_b.hpp
-		include/array_of_doubles_a_not_b_impl.hpp
+		include/array_tuple_sketch.hpp
+		include/array_tuple_sketch_impl.hpp
+		include/array_tuple_union.hpp
+		include/array_tuple_union_impl.hpp
+		include/array_tuple_intersection.hpp
+		include/array_tuple_intersection_impl.hpp
+		include/array_tuple_a_not_b.hpp
+		include/array_tuple_a_not_b_impl.hpp
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/DataSketches")


### PR DESCRIPTION
Addresses install issue reported by @c-dickens via slack.

No CI test added yet since I need to look at how to set that up. Currently just trying to un-break python.