### PR TITLE
register cpc teardown functions for std::atexit

### DIFF
--- a/cpc/include/cpc_compressor.hpp
+++ b/cpc/include/cpc_compressor.hpp
@@ -44,6 +44,10 @@ template<typename A> class cpc_compressor;
 template<typename A>
 inline cpc_compressor<A>& get_compressor();
 
+// function called atexit to clean up compression tables
+template<typename A>
+void destroy_compressor();
+
 template<typename A>
 class cpc_compressor {
 public:
@@ -110,6 +114,8 @@ private:
 
   cpc_compressor();
   template<typename T> friend cpc_compressor<T>& get_compressor();
+  friend void destroy_compressor<A>();
+  
   ~cpc_compressor();
 
   void make_decoding_tables(); // call this at startup

--- a/cpc/include/cpc_compressor.hpp
+++ b/cpc/include/cpc_compressor.hpp
@@ -113,7 +113,7 @@ private:
   };
 
   cpc_compressor();
-  template<typename T> friend cpc_compressor<T>& get_compressor();
+  friend cpc_compressor<A>& get_compressor();
   
   ~cpc_compressor();
   friend void destroy_compressor<A>();

--- a/cpc/include/cpc_compressor.hpp
+++ b/cpc/include/cpc_compressor.hpp
@@ -114,9 +114,9 @@ private:
 
   cpc_compressor();
   template<typename T> friend cpc_compressor<T>& get_compressor();
-  friend void destroy_compressor<A>();
   
   ~cpc_compressor();
+  friend void destroy_compressor<A>();
 
   void make_decoding_tables(); // call this at startup
   void free_decoding_tables(); // call this at the end

--- a/cpc/include/cpc_compressor.hpp
+++ b/cpc/include/cpc_compressor.hpp
@@ -113,7 +113,7 @@ private:
   };
 
   cpc_compressor();
-  friend cpc_compressor<A>& get_compressor();
+  friend cpc_compressor& get_compressor<A>();
   
   ~cpc_compressor();
   friend void destroy_compressor<A>();

--- a/cpc/include/cpc_compressor_impl.hpp
+++ b/cpc/include/cpc_compressor_impl.hpp
@@ -38,8 +38,8 @@ namespace datasketches {
 template<typename A>
 cpc_compressor<A>& get_compressor() {
   static cpc_compressor<A>* instance = new cpc_compressor<A>(); // use new for global initialization
-  static int req_result = std::atexit(destroy_compressor<A>); // just to clean up a little more nicely; don't worry if it fails
-  unused(result);
+  static int reg_result = std::atexit(destroy_compressor<A>); // just to clean up a little more nicely; don't worry if it fails
+  unused(reg_result);
   return *instance;
 }
 

--- a/cpc/include/cpc_compressor_impl.hpp
+++ b/cpc/include/cpc_compressor_impl.hpp
@@ -22,6 +22,7 @@
 #ifndef CPC_COMPRESSOR_IMPL_HPP_
 #define CPC_COMPRESSOR_IMPL_HPP_
 
+#include <cstdlib>
 #include <memory>
 #include <stdexcept>
 
@@ -35,8 +36,19 @@ namespace datasketches {
 // construct on first use
 template<typename A>
 cpc_compressor<A>& get_compressor() {
+  static bool do_init = true;
   static cpc_compressor<A>* instance = new cpc_compressor<A>(); // use new for global initialization
+  if (do_init) {
+    std::atexit(destroy_compressor<A>); // just to clean up a little more nicely; don't worry if it fails
+    do_init = false;
+  }
   return *instance;
+}
+
+// register to call compressor destructor at exit
+template<typename A>
+void destroy_compressor() {
+  delete std::addressof(get_compressor<A>());
 }
 
 template<typename A>

--- a/cpc/include/cpc_compressor_impl.hpp
+++ b/cpc/include/cpc_compressor_impl.hpp
@@ -36,12 +36,8 @@ namespace datasketches {
 // construct on first use
 template<typename A>
 cpc_compressor<A>& get_compressor() {
-  static bool do_init = true;
   static cpc_compressor<A>* instance = new cpc_compressor<A>(); // use new for global initialization
-  if (do_init) {
-    std::atexit(destroy_compressor<A>); // just to clean up a little more nicely; don't worry if it fails
-    do_init = false;
-  }
+  static int req_result = std::atexit(destroy_compressor<A>); // just to clean up a little more nicely; don't worry if it fails
   return *instance;
 }
 

--- a/cpc/include/cpc_compressor_impl.hpp
+++ b/cpc/include/cpc_compressor_impl.hpp
@@ -26,6 +26,7 @@
 #include <memory>
 #include <stdexcept>
 
+#include "common_defs.hpp"
 #include "compression_data.hpp"
 #include "cpc_util.hpp"
 #include "cpc_common.hpp"
@@ -38,6 +39,7 @@ template<typename A>
 cpc_compressor<A>& get_compressor() {
   static cpc_compressor<A>* instance = new cpc_compressor<A>(); // use new for global initialization
   static int req_result = std::atexit(destroy_compressor<A>); // just to clean up a little more nicely; don't worry if it fails
+  unused(result);
   return *instance;
 }
 


### PR DESCRIPTION
`std::atexit()` is apparently considered a legacy C thing since C++ should ideally be able to use static objects. Regardless, this worked to clean up: When I tested in valgrind we finally had a clean report for CPC for the first time ever.