### PR TITLE
Sanitize

### DIFF
--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -1,0 +1,28 @@
+name: Sanitize
+
+on:
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    name: Address Sanitizer
+    runs-on: ubuntu-latest
+            
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+          persist-credentials: false
+      - name: Configure
+        run: cmake -B build -S . -DSANITIZE=address
+      - name: Build C++ unit tests
+        run: cmake --build build --config Release
+      - name: Run C++ tests
+        run: cmake --build build --config Release --target test

--- a/sampling/test/ebpps_sketch_test.cpp
+++ b/sampling/test/ebpps_sketch_test.cpp
@@ -76,6 +76,13 @@ TEST_CASE("ebpps sketch: invalid k", "[ebpps_sketch]") {
   REQUIRE_THROWS_AS(ebpps_sketch<int>(ebpps_constants::MAX_K + 1), std::invalid_argument);
 }
 
+TEST_CASE("leak memory", "[ebpps_sketch]") {
+  int* x = new int[4];
+  x[0] = 5;
+  x[1] = x[0] - 3;
+  REQUIRE(x[0] == x[1] + 3);
+}
+
 TEST_CASE("ebpps sketch: invalid weights", "[ebpps_sketch]") {
   uint32_t k = 100;
   ebpps_sketch<int> sk = create_unweighted_sketch(k, 3);

--- a/sampling/test/ebpps_sketch_test.cpp
+++ b/sampling/test/ebpps_sketch_test.cpp
@@ -76,13 +76,6 @@ TEST_CASE("ebpps sketch: invalid k", "[ebpps_sketch]") {
   REQUIRE_THROWS_AS(ebpps_sketch<int>(ebpps_constants::MAX_K + 1), std::invalid_argument);
 }
 
-TEST_CASE("leak memory", "[ebpps_sketch]") {
-  int* x = new int[4];
-  x[0] = 5;
-  x[1] = x[0] - 3;
-  REQUIRE(x[0] == x[1] + 3);
-}
-
 TEST_CASE("ebpps sketch: invalid weights", "[ebpps_sketch]") {
   uint32_t k = 100;
   ebpps_sketch<int> sk = create_unweighted_sketch(k, 3);


### PR DESCRIPTION
Our cmake config has long supported an option to add a sanitizer but we'd never followed through with doing so. This won't catch quite everything that valgrind or the memory sanitizer will (in particular, read-before-init type errors) but it can check for leaks.

When testing the workflow I created an intentional leak to verify that it did correctly catch the error. See [https://github.com/jmalkin/datasketches-cpp/actions/runs/7394385600](https://github.com/jmalkin/datasketches-cpp/actions/runs/7394385600) to view the output.

The thread sanitizer isn't relevant to us at this point. The memory sanitizer may need to run in docker since it needs a full toolchain compiled with the memory sanitizer enabled. This seems to be all we get for now.

EDIT: A comparison of memory tools can be found [here](https://github.com/google/sanitizers/wiki/AddressSanitizerComparisonOfMemoryTools).