### PR TITLE
density sketch c++17 compatibility

### DIFF
--- a/density/include/density_sketch_impl.hpp
+++ b/density/include/density_sketch_impl.hpp
@@ -144,7 +144,7 @@ void density_sketch<T, K, A>::compact_level(unsigned height) {
   auto& level = levels_[height];
   std::vector<bool> bits(level.size());
   bits[0] = random_utils::random_bit();
-  std::random_shuffle(level.begin(), level.end());
+  std::shuffle(level.begin(), level.end(), random_utils::rand);
   for (unsigned i = 1; i < level.size(); ++i) {
     T delta = 0;
     for (unsigned j = 0; j < i; ++j) {


### PR DESCRIPTION
std::random_shuffle() is removed in c++17 so this ensures strict compatibility with the standard by using a c++11-compatible method to achieve the same goal.