### PR TITLE
Ebpps speedup

### DIFF
--- a/sampling/include/ebpps_sample.hpp
+++ b/sampling/include/ebpps_sample.hpp
@@ -37,13 +37,13 @@ class ebpps_sample {
   public:
     explicit ebpps_sample(uint32_t k, const A& allocator = A());
 
-    // constructor used to create a sample to merge one item
-    template<typename TT>
-    ebpps_sample(TT&& item, double theta, const A& allocator = A());
-
     // for deserialization
     class items_deleter;
     ebpps_sample(std::vector<T, A>&& data, optional<T>&& partial_item, double c, const A& allocator = A());
+
+    // used instead of having a single-item constructor for update/merge calls
+    template<typename TT>
+    void replace_content(TT&& item, double theta);
 
     void reset();
     void downsample(double theta);

--- a/sampling/include/ebpps_sample_impl.hpp
+++ b/sampling/include/ebpps_sample_impl.hpp
@@ -54,9 +54,9 @@ template<typename TT>
 void ebpps_sample<T,A>::replace_content(TT&& item, double theta) {
   c_ = theta;
   data_.clear();
+  partial_item_.reset();
   if (theta == 1.0) {
     data_.emplace_back(std::forward<TT>(item));
-    partial_item_.reset();
   } else {
     partial_item_.emplace(std::forward<TT>(item));
   }

--- a/sampling/include/ebpps_sample_impl.hpp
+++ b/sampling/include/ebpps_sample_impl.hpp
@@ -42,28 +42,25 @@ ebpps_sample<T,A>::ebpps_sample(uint32_t reserved_size, const A& allocator) :
   }
 
 template<typename T, typename A>
-template<typename TT>
-ebpps_sample<T,A>::ebpps_sample(TT&& item, double theta, const A& allocator) :
-  allocator_(allocator),
-  c_(theta),
-  partial_item_(),
-  data_(allocator)
-  {
-    if (theta == 1.0) {
-      data_.reserve(1);
-      data_.emplace_back(std::forward<TT>(item));
-    } else {
-      partial_item_.emplace(std::forward<TT>(item));
-    }
-  }
-
-template<typename T, typename A>
 ebpps_sample<T,A>::ebpps_sample(std::vector<T, A>&& data, optional<T>&& partial_item, double c, const A& allocator) :
   allocator_(allocator),
   c_(c),
   partial_item_(partial_item),
   data_(data, allocator)
   {}
+
+template<typename T, typename A>
+template<typename TT>
+void ebpps_sample<T,A>::replace_content(TT&& item, double theta) {
+  c_ = theta;
+  data_.clear();
+  if (theta == 1.0) {
+    data_.emplace_back(std::forward<TT>(item));
+    partial_item_.reset();
+  } else {
+    partial_item_.emplace(std::forward<TT>(item));
+  }
+}
 
 template<typename T, typename A>
 auto ebpps_sample<T,A>::get_sample() const -> result_type {

--- a/sampling/include/ebpps_sketch.hpp
+++ b/sampling/include/ebpps_sketch.hpp
@@ -256,6 +256,8 @@ class ebpps_sketch {
 
     ebpps_sample<T,A> sample_;      // Object holding the current state of the sample
 
+    ebpps_sample<T,A> tmp_;         // Temporary sample of size 1 used in updates
+
     // handles merge after ensuring other.cumulative_wt_ <= this->cumulative_wt_
     // so we can send items in individually
     template<typename O>

--- a/sampling/test/ebpps_sample_test.cpp
+++ b/sampling/test/ebpps_sample_test.cpp
@@ -42,14 +42,15 @@ TEST_CASE("ebpps sample: basic initialization", "[ebpps_sketch]") {
 
 TEST_CASE("ebpps sample: pre-initialized", "[ebpps_sketch]") {
   double theta = 1.0;
-  ebpps_sample<int> sample = ebpps_sample<int>(-1, theta);
+  ebpps_sample<int> sample(1);
+  sample.replace_content(-1, theta);
   REQUIRE(sample.get_c() == theta);
   REQUIRE(sample.get_num_retained_items() == 1);
   REQUIRE(sample.get_sample().size() == 1);
   REQUIRE(sample.has_partial_item() == false);
   
   theta = 1e-300;
-  sample = ebpps_sample<int>(-1, theta);
+  sample.replace_content(-1, theta);
   REQUIRE(sample.get_c() == theta);
   REQUIRE(sample.get_num_retained_items() == 1);
   REQUIRE(sample.get_sample().size() == 0); // assuming the random number is > 1e-300
@@ -57,7 +58,8 @@ TEST_CASE("ebpps sample: pre-initialized", "[ebpps_sketch]") {
 }
 
 TEST_CASE("ebpps sample: downsampling", "[ebpps_sketch]") {
-  ebpps_sample<char> sample = ebpps_sample<char>('a', 1.0);
+  ebpps_sample<char> sample(1);
+  sample.replace_content('a', 1.0);
 
   sample.downsample(2.0); // no-op
   REQUIRE(sample.get_c() == 1.0);
@@ -121,8 +123,9 @@ TEST_CASE("ebpps sample: merge unit samples", "[ebpps_sketch]") {
   uint32_t k = 8;
   ebpps_sample<int> sample = ebpps_sample<int>(k);
   
+  ebpps_sample<int> s(1);
   for (uint32_t i = 1; i <= k; ++i) {
-    ebpps_sample<int> s = ebpps_sample<int>(i, 1.0);
+    s.replace_content(i, 1.0);
     sample.merge(s);
     REQUIRE(sample.get_c() == static_cast<double>(i));
     REQUIRE(sample.get_num_retained_items() == i);


### PR DESCRIPTION
Keeps a temporary sample of size 1 on-hand for updates/merges to avoid a new std::vector allocation of size 1 each time.  Local manual testing shows a fairly small but consistent benefit (0.1-0.3s out of an 8.4s run)