### PR TITLE
Fix cross-lang tests for Bloom filter

### DIFF
--- a/filters/test/bloom_filter_deserialize_from_java_test.cpp
+++ b/filters/test/bloom_filter_deserialize_from_java_test.cpp
@@ -30,7 +30,7 @@ static std::string testBinaryInputPath = std::string(TEST_BINARY_INPUT_PATH) + "
 
 TEST_CASE("bloom_filter", "[serde_compat]") {
   const uint64_t n_arr[] = {0, 10000, 2000000, 30000000};
-  const double h_arr[] = {3, 5};
+  const uint16_t h_arr[] = {3, 5};
   for (const uint64_t n: n_arr) {
     for (const uint16_t num_hashes: h_arr) {
       std::ifstream is;

--- a/filters/test/bloom_filter_serialize_for_java.cpp
+++ b/filters/test/bloom_filter_serialize_for_java.cpp
@@ -27,11 +27,11 @@ namespace datasketches {
 
 TEST_CASE("bloom filter generate", "[serialize_for_java]") {
   const uint64_t n_arr[] = {0, 10000, 2000000, 30000000};
-  const double h_arr[] = {3, 5};
+  const uint16_t h_arr[] = {3, 5};
   for (const uint64_t n: n_arr) {
     for (const uint16_t num_hashes: h_arr) {
       const uint64_t config_bits = std::max(n, static_cast<uint64_t>(1000)); // so empty still has valid bit size
-      bloom_filter bf = bloom_filter_builder::create_by_size(config_bits, num_hashes);
+      bloom_filter bf = bloom_filter::builder::create_by_size(config_bits, num_hashes);
       for (uint64_t i = 0; i < n / 10; ++i) bf.update(i); // note: n / 10 items into n bits
       if (n > 0) bf.update(std::nan("1")); // include a NaN if non-empty
       REQUIRE(bf.is_empty() == (n == 0));


### PR DESCRIPTION
* fix type on num_hashes to uint16_t
* change bloom_filter_filter to bloom_filter::builder

Added corresponding tests in java and verified locally in both directions.