### PR TITLE
add missing algorithm header

### DIFF
--- a/filters/include/bloom_filter.hpp
+++ b/filters/include/bloom_filter.hpp
@@ -521,7 +521,7 @@ public:
    * @param other A Bloom Filter to check for compatibility with this one
    * @return True if the filters are compatible, otherwise false
    */
-   bool is_compatible(const bloom_filter_alloc& other) const;
+  bool is_compatible(const bloom_filter_alloc& other) const;
 
   /**
    * @brief Checks if the Bloom Filter is read-only.

--- a/filters/include/bloom_filter_impl.hpp
+++ b/filters/include/bloom_filter_impl.hpp
@@ -20,6 +20,7 @@
 #ifndef _BLOOM_FILTER_IMPL_HPP_
 #define _BLOOM_FILTER_IMPL_HPP_
 
+#include <algorithm>
 #include <memory>
 #include <sstream>
 #include <vector>

--- a/tdigest/include/tdigest_impl.hpp
+++ b/tdigest/include/tdigest_impl.hpp
@@ -20,6 +20,7 @@
 #ifndef _TDIGEST_IMPL_HPP_
 #define _TDIGEST_IMPL_HPP_
 
+#include <algorithm>
 #include <cmath>
 #include <sstream>
 


### PR DESCRIPTION
Trying to build python gives errors. Fixed by including in the wrapper itself, but our files shouldn't be missing needed headers.