### PR TITLE
ds-java main branch requires Java 25

### DIFF
--- a/.github/workflows/serde_compat.yml
+++ b/.github/workflows/serde_compat.yml
@@ -12,16 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Checkout Java
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: apache/datasketches-java
           path: java
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
       - name: Run Java
         run: cd java && mvn test -P generate-java-files


### PR DESCRIPTION
This fixes a recent GHA error caused by the fact that the serde_compat.yml workflow specified java 24 instead of 25.

The serde_compat.yml is triggered on a push but not a PR, so I manually triggered it and it passed OK.