### PR TITLE
test: cover req sketch exact mode from serialized bytes

### DIFF
--- a/req/test/req_sketch_deserialize_from_java_test.cpp
+++ b/req/test/req_sketch_deserialize_from_java_test.cpp
@@ -52,4 +52,50 @@ TEST_CASE("req float", "[serde_compat]") {
   }
 }
 
+TEST_CASE("req float negative", "[serde_compat]") {
+  const unsigned n_arr[] = {1, 10};
+  for (const unsigned n: n_arr) {
+    std::ifstream is;
+    is.exceptions(std::ios::failbit | std::ios::badbit);
+    is.open(testBinaryInputPath + "req_float_negative_n" + std::to_string(n) + "_java.sk", std::ios::binary);
+    const auto sketch = req_sketch<float>::deserialize(is);
+    REQUIRE(sketch.is_HRA());
+    REQUIRE_FALSE(sketch.is_empty());
+    REQUIRE_FALSE(sketch.is_estimation_mode());
+    REQUIRE(sketch.get_n() == n);
+    REQUIRE(sketch.get_min_item() == -static_cast<float>(n));
+    REQUIRE(sketch.get_max_item() == -1.0f);
+    uint64_t weight = 0;
+    for (const auto pair: sketch) {
+      REQUIRE(pair.first >= sketch.get_min_item());
+      REQUIRE(pair.first <= sketch.get_max_item());
+      weight += pair.second;
+    }
+    REQUIRE(weight == sketch.get_n());
+  }
+}
+
+TEST_CASE("req float mixed", "[serde_compat]") {
+  const unsigned n_arr[] = {1, 10};
+  for (const unsigned n: n_arr) {
+    std::ifstream is;
+    is.exceptions(std::ios::failbit | std::ios::badbit);
+    is.open(testBinaryInputPath + "req_float_mixed_n" + std::to_string(n) + "_java.sk", std::ios::binary);
+    const auto sketch = req_sketch<float>::deserialize(is);
+    REQUIRE(sketch.is_HRA());
+    REQUIRE_FALSE(sketch.is_empty());
+    REQUIRE_FALSE(sketch.is_estimation_mode());
+    REQUIRE(sketch.get_n() == 2 * n + 1);
+    REQUIRE(sketch.get_min_item() == -static_cast<float>(n));
+    REQUIRE(sketch.get_max_item() == static_cast<float>(n));
+    uint64_t weight = 0;
+    for (const auto pair: sketch) {
+      REQUIRE(pair.first >= sketch.get_min_item());
+      REQUIRE(pair.first <= sketch.get_max_item());
+      weight += pair.second;
+    }
+    REQUIRE(weight == sketch.get_n());
+  }
+}
+
 } /* namespace datasketches */

--- a/req/test/req_sketch_serialize_for_java.cpp
+++ b/req/test/req_sketch_serialize_for_java.cpp
@@ -33,4 +33,24 @@ TEST_CASE("req sketch float generate", "[serialize_for_java]") {
   }
 }
 
+TEST_CASE("req sketch float negative generate", "[serialize_for_java]") {
+  const unsigned n_arr[] = {1, 10};
+  for (const unsigned n: n_arr) {
+    req_sketch<float> sketch(12);
+    for (unsigned i = 1; i <= n; ++i) sketch.update(-static_cast<float>(i));
+    std::ofstream os("req_float_negative_n" + std::to_string(n) + "_cpp.sk", std::ios::binary);
+    sketch.serialize(os);
+  }
+}
+
+TEST_CASE("req sketch float mixed generate", "[serialize_for_java]") {
+  const unsigned n_arr[] = {1, 10};
+  for (const unsigned n: n_arr) {
+    req_sketch<float> sketch(12);
+    for (int i = -static_cast<int>(n); i <= static_cast<int>(n); ++i) sketch.update(static_cast<float>(i));
+    std::ofstream os("req_float_mixed_n" + std::to_string(n) + "_cpp.sk", std::ios::binary);
+    sketch.serialize(os);
+  }
+}
+
 } /* namespace datasketches */

--- a/req/test/req_sketch_test.cpp
+++ b/req/test/req_sketch_test.cpp
@@ -316,6 +316,74 @@ TEST_CASE("req sketch: byte serialize-deserialize estimation mode", "[req_sketch
   REQUIRE(sketch2.get_max_item() == sketch.get_max_item());
 }
 
+TEST_CASE("req sketch: stream serialize-deserialize negative values", "[req_sketch]") {
+  req_sketch<float> sketch(12);
+  const size_t n = 50;
+  for (size_t i = 1; i <= n; ++i) sketch.update(-static_cast<float>(i));
+
+  std::stringstream s(std::ios::in | std::ios::out | std::ios::binary);
+  sketch.serialize(s);
+  auto sketch2 = req_sketch<float>::deserialize(s);
+  REQUIRE(s.tellg() == s.tellp());
+  REQUIRE(sketch2.is_empty() == sketch.is_empty());
+  REQUIRE(sketch2.is_estimation_mode() == sketch.is_estimation_mode());
+  REQUIRE(sketch2.get_num_retained() == sketch.get_num_retained());
+  REQUIRE(sketch2.get_n() == sketch.get_n());
+  REQUIRE(sketch2.get_min_item() == -static_cast<float>(n));
+  REQUIRE(sketch2.get_max_item() == -1.0f);
+}
+
+TEST_CASE("req sketch: byte serialize-deserialize negative values", "[req_sketch]") {
+  req_sketch<float> sketch(12);
+  const size_t n = 50;
+  for (size_t i = 1; i <= n; ++i) sketch.update(-static_cast<float>(i));
+
+  auto bytes = sketch.serialize();
+  REQUIRE(bytes.size() == sketch.get_serialized_size_bytes());
+  auto sketch2 = req_sketch<float>::deserialize(bytes.data(), bytes.size());
+  REQUIRE(bytes.size() == sketch2.get_serialized_size_bytes());
+  REQUIRE(sketch2.is_empty() == sketch.is_empty());
+  REQUIRE(sketch2.is_estimation_mode() == sketch.is_estimation_mode());
+  REQUIRE(sketch2.get_num_retained() == sketch.get_num_retained());
+  REQUIRE(sketch2.get_n() == sketch.get_n());
+  REQUIRE(sketch2.get_min_item() == -static_cast<float>(n));
+  REQUIRE(sketch2.get_max_item() == -1.0f);
+}
+
+TEST_CASE("req sketch: stream serialize-deserialize mixed values", "[req_sketch]") {
+  req_sketch<float> sketch(12);
+  const int half = 25;
+  for (int i = -half; i < half; ++i) sketch.update(static_cast<float>(i));
+
+  std::stringstream s(std::ios::in | std::ios::out | std::ios::binary);
+  sketch.serialize(s);
+  auto sketch2 = req_sketch<float>::deserialize(s);
+  REQUIRE(s.tellg() == s.tellp());
+  REQUIRE(sketch2.is_empty() == sketch.is_empty());
+  REQUIRE(sketch2.is_estimation_mode() == sketch.is_estimation_mode());
+  REQUIRE(sketch2.get_num_retained() == sketch.get_num_retained());
+  REQUIRE(sketch2.get_n() == sketch.get_n());
+  REQUIRE(sketch2.get_min_item() == static_cast<float>(-half));
+  REQUIRE(sketch2.get_max_item() == static_cast<float>(half - 1));
+}
+
+TEST_CASE("req sketch: byte serialize-deserialize mixed values", "[req_sketch]") {
+  req_sketch<float> sketch(12);
+  const int half = 25;
+  for (int i = -half; i < half; ++i) sketch.update(static_cast<float>(i));
+
+  auto bytes = sketch.serialize();
+  REQUIRE(bytes.size() == sketch.get_serialized_size_bytes());
+  auto sketch2 = req_sketch<float>::deserialize(bytes.data(), bytes.size());
+  REQUIRE(bytes.size() == sketch2.get_serialized_size_bytes());
+  REQUIRE(sketch2.is_empty() == sketch.is_empty());
+  REQUIRE(sketch2.is_estimation_mode() == sketch.is_estimation_mode());
+  REQUIRE(sketch2.get_num_retained() == sketch.get_num_retained());
+  REQUIRE(sketch2.get_n() == sketch.get_n());
+  REQUIRE(sketch2.get_min_item() == static_cast<float>(-half));
+  REQUIRE(sketch2.get_max_item() == static_cast<float>(half - 1));
+}
+
 TEST_CASE("req sketch: serialize deserialize stream and bytes equivalence", "[req_sketch]") {
   req_sketch<float> sketch(12);
   const size_t n = 100000;


### PR DESCRIPTION
See this PR: https://github.com/apache/datasketches-java/pull/734

C++ is OK. But to assure compatibility, add test code.

