### PR TITLE
Remove stale Python CMake hook

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,10 +127,6 @@ if (BUILD_BENCHMARKS)
   add_subdirectory(benchmarks)
 endif()
 
-if (WITH_PYTHON)
-  add_subdirectory(python)
-endif()
-
 target_link_libraries(datasketches INTERFACE hll cpc kll fi theta sampling req quantiles count)
 
 if (COVERAGE)


### PR DESCRIPTION
This PR removes the stale `WITH_PYTHON` block from the root CMake configuration. The Python bindings were removed from this repository in #393 after moving to their own project, but the conditional remained and tries to add the nonexistent `python` subdirectory when enabled.