### PR TITLE
Bounds-check per-entry key read in compact_tuple_sketch::deserialize

### DIFF
--- a/tuple/include/tuple_sketch_impl.hpp
+++ b/tuple/include/tuple_sketch_impl.hpp
@@ -583,6 +583,7 @@ compact_tuple_sketch<S, A> compact_tuple_sketch<S, A>::deserialize(const void* b
     std::unique_ptr<S, deleter_of_summaries> summary(alloc.allocate(1), deleter_of_summaries(1, false, allocator));
     for (size_t i = 0; i < num_entries; ++i) {
       uint64_t key;
+      ensure_minimum_memory(base + size - ptr, sizeof(uint64_t));
       ptr += copy_from_mem(ptr, key);
       ptr += sd.deserialize(ptr, base + size - ptr, summary.get(), 1);
       entries.emplace_back(key, std::move(*summary));

--- a/tuple/test/tuple_sketch_test.cpp
+++ b/tuple/test/tuple_sketch_test.cpp
@@ -371,4 +371,19 @@ TEST_CASE("filter", "[tuple_sketch]") {
   }
 }
 
+TEST_CASE("tuple sketch: deserialize with mismatched summary width", "[tuple_sketch]") {
+  // A compact sketch serialized with a narrower summary (float, 4 bytes) and then
+  // deserialized as a wider summary (double, 8 bytes). The per-entry stride the reader
+  // assumes (8-byte key + 8-byte summary) is larger than the entries actually occupy
+  // (8-byte key + 4-byte summary), so the read cursor advances past the end of the buffer.
+  // num_entries is read from the preamble and is unaffected, so the entry loop still runs
+  // the full count and the per-entry key read walks off the end. This must throw rather
+  // than read out of bounds (a heap-buffer-overflow under AddressSanitizer).
+  auto update_sketch = update_tuple_sketch<float>::builder().build();
+  for (int i = 0; i < 100; ++i) update_sketch.update(i, 1.0f);
+  auto bytes = update_sketch.compact().serialize();
+  REQUIRE_THROWS_AS(compact_tuple_sketch<double>::deserialize(bytes.data(), bytes.size()),
+                    std::out_of_range);
+}
+
 } /* namespace datasketches */

--- a/tuple/test/tuple_sketch_test.cpp
+++ b/tuple/test/tuple_sketch_test.cpp
@@ -371,7 +371,7 @@ TEST_CASE("filter", "[tuple_sketch]") {
   }
 }
 
-TEST_CASE("tuple sketch: deserialize with mismatched summary width", "[tuple_sketch]") {
+TEST_CASE("tuple sketch: deserialize bounds-checks each entry key", "[tuple_sketch]") {
   // A compact sketch serialized with a narrower summary (float, 4 bytes) and then
   // deserialized as a wider summary (double, 8 bytes). The per-entry stride the reader
   // assumes (8-byte key + 8-byte summary) is larger than the entries actually occupy


### PR DESCRIPTION
The entry-reading loop reads each entry as an 8-byte key followed by a Summary-width summary. The summary read is passed the remaining capacity and bounds-checks itself, but the key read is an unchecked fixed-size copy_from_mem that relies solely on the pre-loop keys-only reservation, which assumes every entry's summary occupies the width Summary serializes to.

When that assumption does not hold (a truncated buffer, or a buffer whose serialized summary width differs from the Summary it is deserialized as) the read cursor advances past the data. num_entries is read from the preamble and is unaffected, so the loop runs the full count and a later key read walks off the end of the buffer: silent on a normal build, a heap-buffer-overflow under AddressSanitizer.

Add an ensure_minimum_memory check before the key read, mirroring the remaining-capacity check the summary read already performs and the up-front size validation the compact theta parser does. A malformed buffer now throws std::out_of_range instead of reading out of bounds.

Adds a tuple_sketch_test case that deserializes a float-summary sketch as a double-summary sketch and asserts std::out_of_range.