### PR TITLE
Add update_theta_sketch::get_result() to trim to k in one pass

### DIFF
--- a/theta/include/theta_sketch.hpp
+++ b/theta/include/theta_sketch.hpp
@@ -338,10 +338,11 @@ public:
 
   /**
    * Produces a compact sketch trimmed to the nominal size k in a single pass.
-   * Like trim() followed by compact(), but without rebuilding the hash table. Result is unordered.
+   * Like trim() followed by compact(), but without rebuilding the hash table.
+   * @param ordered optional flag to specify if an ordered sketch should be produced
    * @return compact sketch with at most k retained entries
    */
-  compact_theta_sketch_alloc<Allocator> get_result() const;
+  compact_theta_sketch_alloc<Allocator> get_result(bool ordered = true) const;
 
   virtual iterator begin();
   virtual iterator end();

--- a/theta/include/theta_sketch.hpp
+++ b/theta/include/theta_sketch.hpp
@@ -336,6 +336,13 @@ public:
    */
   compact_theta_sketch_alloc<Allocator> compact(bool ordered = true) const;
 
+  /**
+   * Produces a compact sketch trimmed to the nominal size k in a single pass.
+   * Like trim() followed by compact(), but without rebuilding the hash table. Result is unordered.
+   * @return compact sketch with at most k retained entries
+   */
+  compact_theta_sketch_alloc<Allocator> get_result() const;
+
   virtual iterator begin();
   virtual iterator end();
   virtual const_iterator begin() const;
@@ -518,6 +525,7 @@ private:
   template<typename E, typename EK, typename P, typename S, typename CS, typename A> friend class theta_union_base;
   template<typename E, typename EK, typename P, typename S, typename CS, typename A> friend class theta_intersection_base;
   template<typename E, typename EK, typename CS, typename A> friend class theta_set_difference_base;
+  template<typename A> friend class update_theta_sketch_alloc;
   compact_theta_sketch_alloc(bool is_empty, bool is_ordered, uint16_t seed_hash, uint64_t theta, std::vector<uint64_t, Allocator>&& entries);
 };
 

--- a/theta/include/theta_sketch.hpp
+++ b/theta/include/theta_sketch.hpp
@@ -339,6 +339,8 @@ public:
   /**
    * Produces a compact sketch trimmed to the nominal size k in a single pass.
    * Like trim() followed by compact(), but without rebuilding the hash table.
+   * Named get_result() to parallel theta_union::get_result() and
+   * theta_intersection::get_result(), which likewise return an already-trimmed result.
    * @param ordered optional flag to specify if an ordered sketch should be produced
    * @return compact sketch with at most k retained entries
    */

--- a/theta/include/theta_sketch_impl.hpp
+++ b/theta/include/theta_sketch_impl.hpp
@@ -245,7 +245,7 @@ compact_theta_sketch_alloc<A> update_theta_sketch_alloc<A>::compact(bool ordered
 }
 
 template<typename A>
-compact_theta_sketch_alloc<A> update_theta_sketch_alloc<A>::get_result() const {
+compact_theta_sketch_alloc<A> update_theta_sketch_alloc<A>::get_result(bool ordered) const {
   std::vector<uint64_t, A> entries(table_.allocator_);
   if (is_empty()) {
     return compact_theta_sketch_alloc<A>(true, true, get_seed_hash(), get_theta64(), std::move(entries));
@@ -259,7 +259,7 @@ compact_theta_sketch_alloc<A> update_theta_sketch_alloc<A>::get_result() const {
     theta = entries[nominal_num];
     entries.erase(entries.begin() + nominal_num, entries.end());
   }
-  const bool ordered = entries.size() <= 1;
+  if (ordered) std::sort(entries.begin(), entries.end());
   return compact_theta_sketch_alloc<A>(false, ordered, get_seed_hash(), theta, std::move(entries));
 }
 

--- a/theta/include/theta_sketch_impl.hpp
+++ b/theta/include/theta_sketch_impl.hpp
@@ -23,6 +23,7 @@
 #include <sstream>
 #include <vector>
 #include <stdexcept>
+#include <algorithm>
 
 #include "binomial_bounds.hpp"
 #include "theta_helpers.hpp"
@@ -241,6 +242,25 @@ auto update_theta_sketch_alloc<A>::end() const -> const_iterator {
 template<typename A>
 compact_theta_sketch_alloc<A> update_theta_sketch_alloc<A>::compact(bool ordered) const {
   return compact_theta_sketch_alloc<A>(*this, ordered);
+}
+
+template<typename A>
+compact_theta_sketch_alloc<A> update_theta_sketch_alloc<A>::get_result() const {
+  std::vector<uint64_t, A> entries(table_.allocator_);
+  if (is_empty()) {
+    return compact_theta_sketch_alloc<A>(true, true, get_seed_hash(), get_theta64(), std::move(entries));
+  }
+  entries.reserve(get_num_retained());
+  std::copy(begin(), end(), std::back_inserter(entries));
+  uint64_t theta = table_.theta_;
+  const uint32_t nominal_num = 1 << table_.lg_nom_size_;
+  if (entries.size() > nominal_num) {
+    std::nth_element(entries.begin(), entries.begin() + nominal_num, entries.end());
+    theta = entries[nominal_num];
+    entries.erase(entries.begin() + nominal_num, entries.end());
+  }
+  const bool ordered = entries.size() <= 1;
+  return compact_theta_sketch_alloc<A>(false, ordered, get_seed_hash(), theta, std::move(entries));
 }
 
 template<typename A>

--- a/theta/test/theta_sketch_test.cpp
+++ b/theta/test/theta_sketch_test.cpp
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <vector>
 #include <stdexcept>
+#include <algorithm>
 
 #include <catch2/catch.hpp>
 #include <theta_sketch.hpp>
@@ -165,6 +166,49 @@ TEST_CASE("theta sketch: estimation", "[theta_sketch]") {
   REQUIRE(compact_sketch.get_estimate() == Approx((double) n).margin(n * 0.01));
   REQUIRE(compact_sketch.get_lower_bound(1) < n);
   REQUIRE(compact_sketch.get_upper_bound(1) > n);
+}
+
+TEST_CASE("theta sketch: get_result trims to k in one pass", "[theta_sketch]") {
+  update_theta_sketch update_sketch = update_theta_sketch::builder().build();
+  const int n = 8000;
+  for (int i = 0; i < n; i++) update_sketch.update(i);
+  const uint32_t k = 1 << theta_constants::DEFAULT_LG_K;
+  REQUIRE(update_sketch.get_num_retained() > k); // over-provisioned before trimming
+
+  compact_theta_sketch result = update_sketch.get_result();
+  REQUIRE_FALSE(result.is_empty());
+  REQUIRE(result.is_estimation_mode());
+  REQUIRE(result.get_num_retained() == k); // trimmed to nominal size
+  REQUIRE_FALSE(result.is_ordered());      // unordered: no sort performed
+
+  // fused get_result() must match trim() + compact()
+  update_theta_sketch trimmed = update_sketch;
+  trimmed.trim();
+  compact_theta_sketch expected = trimmed.compact(false);
+  REQUIRE(result.get_theta64() == expected.get_theta64());
+  REQUIRE(result.get_num_retained() == expected.get_num_retained());
+  REQUIRE(result.get_estimate() == expected.get_estimate());
+
+  // same set of retained hashes (order-independent)
+  std::vector<uint64_t> a(result.begin(), result.end());
+  std::vector<uint64_t> b(expected.begin(), expected.end());
+  std::sort(a.begin(), a.end());
+  std::sort(b.begin(), b.end());
+  REQUIRE(a == b);
+}
+
+TEST_CASE("theta sketch: get_result on empty and below-k sketches", "[theta_sketch]") {
+  compact_theta_sketch empty_result = update_theta_sketch::builder().build().get_result();
+  REQUIRE(empty_result.is_empty());
+  REQUIRE(empty_result.get_num_retained() == 0);
+
+  update_theta_sketch small = update_theta_sketch::builder().build();
+  for (int i = 0; i < 100; i++) small.update(i);
+  REQUIRE_FALSE(small.is_estimation_mode());
+  compact_theta_sketch small_result = small.get_result();
+  REQUIRE_FALSE(small_result.is_estimation_mode());
+  REQUIRE(small_result.get_num_retained() == 100); // below k: nothing trimmed
+  REQUIRE(small_result.get_estimate() == Approx(100.0));
 }
 
 TEST_CASE("theta sketch: deserialize compact v1 empty from java", "[theta_sketch]") {

--- a/theta/test/theta_sketch_test.cpp
+++ b/theta/test/theta_sketch_test.cpp
@@ -175,40 +175,52 @@ TEST_CASE("theta sketch: get_result trims to k in one pass", "[theta_sketch]") {
   const uint32_t k = 1 << theta_constants::DEFAULT_LG_K;
   REQUIRE(update_sketch.get_num_retained() > k); // over-provisioned before trimming
 
-  compact_theta_sketch result = update_sketch.get_result();
-  REQUIRE_FALSE(result.is_empty());
-  REQUIRE(result.is_estimation_mode());
-  REQUIRE(result.get_num_retained() == k); // trimmed to nominal size
-  REQUIRE_FALSE(result.is_ordered());      // unordered: no sort performed
+  // default is ordered, matching union/intersection get_result
+  compact_theta_sketch ordered_result = update_sketch.get_result();
+  REQUIRE_FALSE(ordered_result.is_empty());
+  REQUIRE(ordered_result.is_estimation_mode());
+  REQUIRE(ordered_result.get_num_retained() == k); // trimmed to nominal size
+  REQUIRE(ordered_result.is_ordered());
+  REQUIRE(std::is_sorted(ordered_result.begin(), ordered_result.end()));
 
-  // fused get_result() must match trim() + compact()
+  // fused get_result(true) must match trim() + compact(true)
   update_theta_sketch trimmed = update_sketch;
   trimmed.trim();
-  compact_theta_sketch expected = trimmed.compact(false);
-  REQUIRE(result.get_theta64() == expected.get_theta64());
-  REQUIRE(result.get_num_retained() == expected.get_num_retained());
-  REQUIRE(result.get_estimate() == expected.get_estimate());
+  compact_theta_sketch expected = trimmed.compact(true);
+  REQUIRE(ordered_result.get_theta64() == expected.get_theta64());
+  REQUIRE(ordered_result.get_num_retained() == expected.get_num_retained());
+  REQUIRE(ordered_result.get_estimate() == expected.get_estimate());
+  REQUIRE(std::vector<uint64_t>(ordered_result.begin(), ordered_result.end())
+          == std::vector<uint64_t>(expected.begin(), expected.end()));
 
-  // same set of retained hashes (order-independent)
-  std::vector<uint64_t> a(result.begin(), result.end());
-  std::vector<uint64_t> b(expected.begin(), expected.end());
-  std::sort(a.begin(), a.end());
-  std::sort(b.begin(), b.end());
-  REQUIRE(a == b);
+  // unordered variant: same trimmed set and theta, no sort
+  compact_theta_sketch unordered_result = update_sketch.get_result(false);
+  REQUIRE_FALSE(unordered_result.is_ordered());
+  REQUIRE(unordered_result.get_num_retained() == k);
+  REQUIRE(unordered_result.get_theta64() == expected.get_theta64());
+  std::vector<uint64_t> unordered_hashes(unordered_result.begin(), unordered_result.end());
+  std::sort(unordered_hashes.begin(), unordered_hashes.end());
+  REQUIRE(unordered_hashes == std::vector<uint64_t>(expected.begin(), expected.end()));
 }
 
 TEST_CASE("theta sketch: get_result on empty and below-k sketches", "[theta_sketch]") {
   compact_theta_sketch empty_result = update_theta_sketch::builder().build().get_result();
   REQUIRE(empty_result.is_empty());
   REQUIRE(empty_result.get_num_retained() == 0);
+  REQUIRE(empty_result.is_ordered());
 
   update_theta_sketch small = update_theta_sketch::builder().build();
   for (int i = 0; i < 100; i++) small.update(i);
   REQUIRE_FALSE(small.is_estimation_mode());
-  compact_theta_sketch small_result = small.get_result();
+
+  compact_theta_sketch small_result = small.get_result(); // default ordered
   REQUIRE_FALSE(small_result.is_estimation_mode());
   REQUIRE(small_result.get_num_retained() == 100); // below k: nothing trimmed
   REQUIRE(small_result.get_estimate() == Approx(100.0));
+  REQUIRE(small_result.is_ordered());
+  REQUIRE(std::is_sorted(small_result.begin(), small_result.end()));
+
+  REQUIRE_FALSE(small.get_result(false).is_ordered()); // unordered variant
 }
 
 TEST_CASE("theta sketch: deserialize compact v1 empty from java", "[theta_sketch]") {


### PR DESCRIPTION
## What changed

Add `get_result()` to `update_theta_sketch_alloc`. It returns a `compact_theta_sketch` trimmed to at most the nominal size `k` (`2^lg_k`) in a single pass, without rebuilding the hash table.

Background: an update sketch's hash table retains up to `~15/16 * 2k` entries between rebuilds, and `compact()` intentionally keeps all of them (extra entries below theta improve the estimate). To trim a result on`k` today, a caller does `trim()` then `compact()`, this is too slow and inneificent (does malloc, dealloc).

I named this function `get_result()` in reference to theta union (and likely intersectino) which gurantee to return a already trimmed result.

## How tested

- `get_result trims to k in one pass`: builds an 8000-item sketch (retains more than `k`); asserts the default `get_result()` returns exactly `k` ordered entries matching `trim()` + `compact(true)` (same theta and retained set), and that `get_result(false)` returns the same trimmed set unordered.
- `get_result on empty and below-k sketches`: empty stays empty and ordered; a 100-item exact-mode sketch returns untrimmed with all entries, ordered by default.

Local run:

```
cmake --build build --target theta_test -j
./build/theta/test/theta_test "[theta_sketch]"
# All tests passed (85773 assertions in 34 test cases)
```
