### PR TITLE
Report a zero seed hash for an empty compact sketch

### DIFF
--- a/theta/include/theta_set_difference_base_impl.hpp
+++ b/theta/include/theta_set_difference_base_impl.hpp
@@ -39,7 +39,9 @@ template<typename FwdSketch, typename Sketch>
 CS theta_set_difference_base<EN, EK, CS, A>::compute(FwdSketch&& a, const Sketch& b, bool ordered) const {
   if (a.is_empty() || (a.get_num_retained() > 0 && b.is_empty())) return CS(a, ordered);
   if (a.get_seed_hash() != seed_hash_) throw std::invalid_argument("A seed hash mismatch");
-  if (b.get_seed_hash() != seed_hash_) throw std::invalid_argument("B seed hash mismatch");
+  // an empty sketch has no hashes, so its seed hash is meaningless and must be ignored,
+  // consistent with deserialization, theta_union::update() and theta_intersection::update()
+  if (!b.is_empty() && b.get_seed_hash() != seed_hash_) throw std::invalid_argument("B seed hash mismatch");
 
   const uint64_t theta = std::min(a.get_theta64(), b.get_theta64());
   std::vector<EN, A> entries(allocator_);

--- a/theta/include/theta_sketch_impl.hpp
+++ b/theta/include/theta_sketch_impl.hpp
@@ -315,7 +315,7 @@ uint32_t compact_theta_sketch_alloc<A>::get_num_retained() const {
 
 template<typename A>
 uint16_t compact_theta_sketch_alloc<A>::get_seed_hash() const {
-  return seed_hash_;
+  return is_empty_ ? 0 : seed_hash_;
 }
 
 template<typename A>
@@ -782,7 +782,7 @@ uint32_t wrapped_compact_theta_sketch_alloc<A>::get_num_retained() const {
 
 template<typename A>
 uint16_t wrapped_compact_theta_sketch_alloc<A>::get_seed_hash() const {
-  return data_.seed_hash;
+  return is_empty() ? 0 : data_.seed_hash;
 }
 
 template<typename A>

--- a/theta/test/theta_a_not_b_test.cpp
+++ b/theta/test/theta_a_not_b_test.cpp
@@ -241,6 +241,28 @@ TEST_CASE("theta a-not-b: seed mismatch", "[theta_a_not_b]") {
   REQUIRE_THROWS_AS(a_not_b.compute(sketch, sketch), std::invalid_argument);
 }
 
+TEST_CASE("theta a-not-b: empty B with different seed must be ignored", "[theta_a_not_b]") {
+  // An empty sketch carries no hashes, so its seed hash is meaningless. Deserialization,
+  // theta_union::update() and theta_intersection::update() all skip the seed hash check
+  // for empty inputs; a-not-b must do the same. This matters across languages because
+  // datasketches-java serializes every empty compact sketch with a seed hash of 0.
+
+  // A: non-empty, but with zero retained entries (all hashes exceeded theta)
+  update_theta_sketch a = update_theta_sketch::builder().set_p(1e-6f).build();
+  a.update(1);
+  REQUIRE_FALSE(a.is_empty());
+  REQUIRE(a.get_num_retained() == 0);
+
+  // B: empty, built with a different seed
+  compact_theta_sketch b = update_theta_sketch::builder().set_seed(123).build().compact();
+  REQUIRE(b.is_empty());
+
+  theta_a_not_b a_not_b; // default seed
+  compact_theta_sketch result = a_not_b.compute(a.compact(), b);
+  REQUIRE_FALSE(result.is_empty());
+  REQUIRE(result.get_num_retained() == 0);
+}
+
 TEST_CASE("theta a-not-b: issue #152", "[theta_a_not_b]") {
   update_theta_sketch a = update_theta_sketch::builder().build();
   int value = 0;

--- a/tuple/include/tuple_sketch_impl.hpp
+++ b/tuple/include/tuple_sketch_impl.hpp
@@ -347,7 +347,7 @@ uint32_t compact_tuple_sketch<S, A>::get_num_retained() const {
 
 template<typename S, typename A>
 uint16_t compact_tuple_sketch<S, A>::get_seed_hash() const {
-  return seed_hash_;
+  return is_empty_ ? 0 : seed_hash_;
 }
 
 template<typename S, typename A>


### PR DESCRIPTION
Follow-up to #517, which this is stacked on. It is the write half of what @leerho described there: make an empty compact sketch report a zero seed hash so it matches Java.

`EmptyCompactSketch` in Java does two things. `getSeedHash()` returns `0`, and the serialized singleton is `{ 1, 3, 3, 0, 0, 0x1E, 0, 0 }` with zeros in the seed hash position. The recognition mask `0X00_00_EB_00_00_FF_FF_FF` has `00_00` in the top two bytes, so those bytes are excluded from the test rather than merely conventionally ignored.

C++ carried `compute_seed_hash(seed)` for an empty compact sketch, so the bytes differed from Java. After this an empty sketch serializes to `1 3 3 0 0 30 0 0`, the same eight bytes Java writes.

Three accessors carry it, since making it accessor level rather than serialization level is what matches Java: `compact_theta_sketch_alloc`, `wrapped_compact_theta_sketch_alloc`, and `compact_tuple_sketch`.

**Why it is stacked rather than standalone.** On its own this is a regression. `theta_set_difference_base::compute` checks B's seed hash, and its early return only covers an empty B when A has retained entries, so an A that is non-empty with zero retained reaches the check. Today both sides carry the same computed hash and it passes; with this change B would carry 0 and it would throw. I confirmed that on a real sketch rather than reasoning about it:

```
A: is_empty=0 retained=0 seed_hash=37836
B: is_empty=1            seed_hash=37836
early return taken? no
a_not_b: OK
```

#517 adds the `!b.is_empty()` guard that closes it, which is why this sits on top. Please take #517 first.

The other three seed checks were already safe: `theta_union_base::update` returns early on empty, `theta_intersection_base::update` has `!sketch.is_empty() &&`, and `deserialize_v3` has `if (!is_empty) check_seed_hash(...)`, so a zero hash on an empty image reads back fine. `deserialize_v1`/`v2` check unconditionally, but those parse SerVer 1 and 2 images and nothing writes an empty sketch in those formats here.

All 17 ctest suites pass, including the theta and tuple cross-language serde tests.

Generated with Claude Code; I ran the checks above myself.
