### PR TITLE
Add an Apache RAT license-header audit to CI

### DIFF
--- a/.github/workflows/rat.yml
+++ b/.github/workflows/rat.yml
@@ -1,0 +1,30 @@
+name: License Audit
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  rat:
+    name: Apache RAT
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Run Apache RAT
+        run: tools/rat-check.sh

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -1,0 +1,26 @@
+# Files excluded from the Apache RAT license-header audit.
+#
+# NOTE: RAT matches these regular expressions against the FILE NAME, not the path.
+#
+# Third-party sources vendored into this tree do not carry the ASF header; they
+# keep their own notice and are enumerated in LICENSE. When adding one here, add
+# the matching entry to LICENSE in the same commit.
+MurmurHash3\.h
+xxhash64\.h
+#
+# Dotfiles and repository metadata with no comment convention.
+\..*
+#
+# Documentation.
+README\.md
+CONTRIBUTING\.md
+CODE_OF_CONDUCT\.md
+#
+# Generated and template files consumed by the build.
+Doxyfile
+version\.cfg\.in
+DataSketchesConfig\.cmake\.in
+#
+# The license texts themselves.
+LICENSE
+NOTICE

--- a/hll/include/hll.private.hpp
+++ b/hll/include/hll.private.hpp
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 #ifndef _HLL_PRIVATE_HPP_
 #define _HLL_PRIVATE_HPP_
 

--- a/tools/rat-check.sh
+++ b/tools/rat-check.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Runs the Apache Release Audit Tool over the tracked files of this repository
+# and fails if any file lacks an approved license header.
+#
+# Only tracked files are examined: the tree is exported with `git archive`, so a
+# local build directory or other untracked scratch cannot affect the result.
+#
+# Usage:  tools/rat-check.sh [git-ref]      (default: HEAD)
+
+set -euo pipefail
+
+RAT_VERSION="${RAT_VERSION:-0.16.1}"
+RAT_JAR="${RAT_JAR:-}"
+REF="${1:-HEAD}"
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+if [[ -z "$RAT_JAR" ]]; then
+  RAT_JAR="$work/apache-rat.jar"
+  url="https://repo1.maven.org/maven2/org/apache/rat/apache-rat/${RAT_VERSION}/apache-rat-${RAT_VERSION}.jar"
+  echo "Downloading Apache RAT ${RAT_VERSION}"
+  curl -fsSL -o "$RAT_JAR" "$url"
+fi
+
+mkdir -p "$work/src"
+git archive "$REF" | tar -x -C "$work/src"
+cp .rat-excludes "$work/src/.rat-excludes"
+
+report="$work/rat-report.txt"
+java -jar "$RAT_JAR" -E "$work/src/.rat-excludes" -d "$work/src" > "$report" 2>/dev/null
+
+unknown="$(sed -n 's/^\([0-9][0-9]*\) Unknown Licenses$/\1/p' "$report" | head -1)"
+unknown="${unknown:-0}"
+
+if [[ "$unknown" -ne 0 ]]; then
+  echo
+  echo "Apache RAT found ${unknown} file(s) without an approved license header:"
+  awk '/^Files with unapproved licenses:/{f=1;next} f&&/^\*\*\*\*/{exit} f&&NF{print "  " $0}' "$report" \
+    | sed "s|$work/src/||"
+  echo
+  echo "Add the ASF header to each file. If a file is third-party source that must"
+  echo "keep its own notice, add it to .rat-excludes AND record it in LICENSE."
+  exit 1
+fi
+
+echo "Apache RAT: all tracked files carry an approved license header."


### PR DESCRIPTION
# Add an Apache RAT license-header audit to CI

## The gap

This repository has no automated license check. Nothing in the build system knows which files are third-party, so a vendored source file can be added with **no ASF header and no LICENSE entry** and every existing check still passes.

That is not hypothetical. It happened while preparing the HLL cross-language parity work: a vendored FDLIBM header was added to `common/include/` and all 31 CI checks went green with no LICENSE entry. The omission would have surfaced only in a release audit.

## Why C++ makes this easier to get wrong than Java

In a Maven project every dependency is a coordinate in the POM, resolved and versioned by the tool. Here dependencies arrive two different ways, and only one of them is declared anywhere:

| how it arrives | where it is declared |
|---|---|
| fetched at build time — Catch2 `v2.13.9`, google-benchmark `v1.7.1` | CMake `FetchContent`, pinned by tag |
| **vendored — copied into the tree** | **`LICENSE` only, maintained by hand** |

There is no `conanfile`, no `vcpkg.json`, no manifest of any kind. The library itself links nothing external — `hll` links only `common`, both header-only INTERFACE targets — so a consumer just copies headers. That is a virtue for consumers and a hazard for compliance: the vendored files exist purely as files.

Grep is not a substitute. Of the vendored headers, `MurmurHash3.h` and `ceiling_power_of_2.hpp` state their provenance in prose without the word "Copyright", so scanning the source does not reliably enumerate them either.

## What this adds

- **`tools/rat-check.sh`** — exports the tree with `git archive` so only tracked files are examined, runs Apache RAT, parses the report and exits non-zero on any unapproved file, printing the offending paths and what to do about them.
- **`.github/workflows/rat.yml`** — runs it on push and pull request.
- **`.rat-excludes`** — the exclusions, grouped and commented, with a note at the top of the third-party group that adding a file there also requires a LICENSE entry.

Two things worth knowing about the implementation:

- **RAT always exits 0.** Version 0.16.1 has no `--fail` option, so a naive `java -jar rat.jar` step is a check that can never fail. The script parses the `N Unknown Licenses` line instead.
- **`git archive` rather than the working tree.** Only tracked files are scanned, so a local build directory cannot affect the result, and the check runs locally exactly as CI runs it. On a dirty tree RAT reports 827 unknowns; on the tracked set it reports 0.
- **RAT matches `-E` patterns against the file name, not the path.** This is undocumented in the CLI help and cost two wrong attempts; the file says so at the top.

## It found something on the first run

`hll/include/hll.private.hpp` carried no ASF header, while every sibling header in that directory does. Fixed here.

## Verification

- With the header fix, the tracked tree reports **0 unapproved files**.
- Negative test: adding a header-less file to a copy of the tree is caught — `1 Unknown Licenses`, naming the file, exit code 1.
- Exclusions were derived from what RAT actually reports on this repository, not copied from the Java project, whose list is shaped for a Maven tree (its `**/*.txt` would skip every `CMakeLists.txt`, which here does carry an ASF header and should be checked).
