### PR TITLE
Add optional trim flag to update_theta_sketch::compact()

### DIFF
--- a/theta/include/theta_helpers.hpp
+++ b/theta/include/theta_helpers.hpp
@@ -20,12 +20,44 @@
 #ifndef THETA_HELPERS_HPP_
 #define THETA_HELPERS_HPP_
 
+#include <algorithm>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include "theta_constants.hpp"
+#include "theta_comparators.hpp"
 
 namespace datasketches {
+
+/**
+ * Trims a vector of theta entries down to at most nominal_size and returns the theta the
+ * result must carry.
+ *
+ * The entry at index nominal_size becomes the new theta and is itself discarded, so every
+ * entry kept is strictly below the returned value. That is what keeps the estimator
+ * unbiased: theta must be an exclusive upper bound on the retained hashes. Getting this
+ * off by one does not fail loudly, it quietly biases every estimate the sketch produces.
+ *
+ * Capacity is released as well as size. Callers reserve an upper bound before filling, so
+ * without the shrink a trimmed result keeps the untrimmed allocation, which for an update
+ * sketch just under the rebuild threshold is nearly twice what it reports.
+ *
+ * @param entries entries to trim in place; reordered even when nothing is removed
+ * @param nominal_size the most entries to keep
+ * @param theta returned unchanged when there is nothing to trim
+ * @return the theta of the trimmed result
+ */
+template<typename ExtractKey, typename Entry, typename Allocator>
+static uint64_t trim_to_nominal(std::vector<Entry, Allocator>& entries, uint32_t nominal_size, uint64_t theta) {
+  if (entries.size() <= nominal_size) return theta;
+  std::nth_element(entries.begin(), entries.begin() + nominal_size, entries.end(), compare_by_key<ExtractKey>());
+  const uint64_t new_theta = ExtractKey()(entries[nominal_size]);
+  entries.erase(entries.begin() + nominal_size, entries.end());
+  entries.shrink_to_fit();
+  return new_theta;
+}
 
 template<typename T>
 static void check_value(T actual, T expected, const char* description) {

--- a/theta/include/theta_sketch.hpp
+++ b/theta/include/theta_sketch.hpp
@@ -330,11 +330,25 @@ public:
   void reset();
 
   /**
-   * Converts this sketch to a compact sketch (ordered or unordered).
+   * Converts this sketch to a compact sketch (ordered or unordered, trimmed or not trimmed).
+   * This does not modify the source update sketch.
    * @param ordered optional flag to specify if an ordered sketch should be produced
+   * @param trim optional flag to reduce the size of the returned sketch to at most
+   * the nominal size k, if required. An update sketch retains more than k entries
+   * between rebuilds; those extra entries below theta improve the estimate, so the
+   * default is to keep them.
+   * Trimming is lossy and is never required for correctness. It discards retained
+   * entries, and since the relative error scales with 1 / sqrt(retained), it always
+   * degrades accuracy and widens the confidence bounds, whatever mode the source is
+   * in. Worst case, a sketch grown to just under the rebuild threshold of 15/16 * 2k
+   * loses nearly half its entries, widening the bounds by about sqrt(15/8), or
+   * roughly 37%. A sketch in exact mode that retains more than k entries loses
+   * exactness as well: it is returned in estimation mode, so get_estimate() carries
+   * error where it would otherwise have returned an exact count.
+   * Only pass true if a bounded result size matters more than that accuracy.
    * @return compact sketch
    */
-  compact_theta_sketch_alloc<Allocator> compact(bool ordered = true) const;
+  compact_theta_sketch_alloc<Allocator> compact(bool ordered = true, bool trim = false) const;
 
   virtual iterator begin();
   virtual iterator end();
@@ -518,6 +532,7 @@ private:
   template<typename E, typename EK, typename P, typename S, typename CS, typename A> friend class theta_union_base;
   template<typename E, typename EK, typename P, typename S, typename CS, typename A> friend class theta_intersection_base;
   template<typename E, typename EK, typename CS, typename A> friend class theta_set_difference_base;
+  template<typename A> friend class update_theta_sketch_alloc;
   compact_theta_sketch_alloc(bool is_empty, bool is_ordered, uint16_t seed_hash, uint64_t theta, std::vector<uint64_t, Allocator>&& entries);
 };
 

--- a/theta/include/theta_sketch_impl.hpp
+++ b/theta/include/theta_sketch_impl.hpp
@@ -252,13 +252,7 @@ compact_theta_sketch_alloc<A> update_theta_sketch_alloc<A>::compact(bool ordered
   std::copy(this->begin(), this->end(), std::back_inserter(entries));
   uint64_t theta = this->get_theta64();
   const uint32_t nominal_size = 1 << table_.lg_nom_size_;
-  if (entries.size() > nominal_size) {
-    // partial sort so that entries[nominal_size] is the (nominal_size + 1)-th smallest hash;
-    // it becomes the new theta, and the nominal_size entries below it are all we keep
-    std::nth_element(entries.begin(), entries.begin() + nominal_size, entries.end());
-    theta = entries[nominal_size];
-    entries.erase(entries.begin() + nominal_size, entries.end());
-  }
+  theta = trim_to_nominal<trivial_extract_key>(entries, nominal_size, theta);
   if (ordered) std::sort(entries.begin(), entries.end());
   return compact_theta_sketch_alloc<A>(false, ordered, this->get_seed_hash(), theta, std::move(entries));
 }

--- a/theta/include/theta_sketch_impl.hpp
+++ b/theta/include/theta_sketch_impl.hpp
@@ -23,6 +23,7 @@
 #include <sstream>
 #include <vector>
 #include <stdexcept>
+#include <algorithm>
 
 #include "binomial_bounds.hpp"
 #include "theta_helpers.hpp"
@@ -239,8 +240,27 @@ auto update_theta_sketch_alloc<A>::end() const -> const_iterator {
 }
 
 template<typename A>
-compact_theta_sketch_alloc<A> update_theta_sketch_alloc<A>::compact(bool ordered) const {
-  return compact_theta_sketch_alloc<A>(*this, ordered);
+compact_theta_sketch_alloc<A> update_theta_sketch_alloc<A>::compact(bool ordered, bool trim) const {
+  if (!trim) return compact_theta_sketch_alloc<A>(*this, ordered);
+
+  std::vector<uint64_t, A> entries(table_.allocator_);
+  if (this->is_empty()) {
+    return compact_theta_sketch_alloc<A>(true, true, this->get_seed_hash(), this->get_theta64(), std::move(entries));
+  }
+  // copy first: this method is const, and quick select would permute the source table
+  entries.reserve(this->get_num_retained());
+  std::copy(this->begin(), this->end(), std::back_inserter(entries));
+  uint64_t theta = this->get_theta64();
+  const uint32_t nominal_size = 1 << table_.lg_nom_size_;
+  if (entries.size() > nominal_size) {
+    // partial sort so that entries[nominal_size] is the (nominal_size + 1)-th smallest hash;
+    // it becomes the new theta, and the nominal_size entries below it are all we keep
+    std::nth_element(entries.begin(), entries.begin() + nominal_size, entries.end());
+    theta = entries[nominal_size];
+    entries.erase(entries.begin() + nominal_size, entries.end());
+  }
+  if (ordered) std::sort(entries.begin(), entries.end());
+  return compact_theta_sketch_alloc<A>(false, ordered, this->get_seed_hash(), theta, std::move(entries));
 }
 
 template<typename A>

--- a/theta/include/theta_union_base_impl.hpp
+++ b/theta/include/theta_union_base_impl.hpp
@@ -24,6 +24,7 @@
 #include <stdexcept>
 
 #include "conditional_forward.hpp"
+#include "theta_helpers.hpp"
 
 namespace datasketches {
 
@@ -70,12 +71,7 @@ CS theta_union_base<EN, EK, P, S, CS, A>::get_result(bool ordered) const {
   } else {
     std::copy_if(table_.begin(), table_.end(), std::back_inserter(entries), key_not_zero_less_than<uint64_t, EN, EK>(theta));
   }
-  if (entries.size() > nominal_num) {
-    std::nth_element(entries.begin(), entries.begin() + nominal_num, entries.end(), comparator());
-    theta = EK()(entries[nominal_num]);
-    entries.erase(entries.begin() + nominal_num, entries.end());
-    entries.shrink_to_fit();
-  }
+  theta = trim_to_nominal<EK>(entries, nominal_num, theta);
   if (ordered) std::sort(entries.begin(), entries.end(), comparator());
   return CS(table_.is_empty_, ordered, compute_seed_hash(table_.seed_), theta, std::move(entries));
 }

--- a/theta/test/theta_sketch_test.cpp
+++ b/theta/test/theta_sketch_test.cpp
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <vector>
 #include <stdexcept>
+#include <algorithm>
 
 #include <catch2/catch.hpp>
 #include <theta_sketch.hpp>
@@ -149,6 +150,130 @@ TEST_CASE("theta sketch: single item", "[theta_sketch]") {
 
   // single item is forced to be ordered
   REQUIRE(update_sketch.compact(false).is_ordered());
+}
+
+TEST_CASE("theta sketch: compact with trim, all four cases", "[theta_sketch]") {
+  update_theta_sketch update_sketch = update_theta_sketch::builder().build();
+  for (int i = 0; i < 8000; i++) update_sketch.update(i);
+  const uint32_t k = 1 << theta_constants::DEFAULT_LG_K;
+  // an update sketch retains more than k between rebuilds, so trimming has work to do
+  REQUIRE(update_sketch.get_num_retained() > k);
+  const uint32_t retained_before = update_sketch.get_num_retained();
+  const uint64_t theta_before = update_sketch.get_theta64();
+
+  // the trimmed result is what trim() + compact() would produce
+  update_theta_sketch trimmed = update_sketch;
+  trimmed.trim();
+  compact_theta_sketch expected = trimmed.compact(true);
+  const std::vector<uint64_t> expected_entries(expected.begin(), expected.end());
+
+  // case 1: ordered, not trimmed (the default) keeps every retained entry
+  compact_theta_sketch c1 = update_sketch.compact(true, false);
+  REQUIRE(c1.is_ordered());
+  REQUIRE(c1.get_num_retained() == retained_before);
+  REQUIRE(c1.get_theta64() == theta_before);
+  REQUIRE(std::is_sorted(c1.begin(), c1.end()));
+
+  // case 2: unordered, not trimmed
+  compact_theta_sketch c2 = update_sketch.compact(false, false);
+  REQUIRE_FALSE(c2.is_ordered());
+  REQUIRE(c2.get_num_retained() == retained_before);
+  REQUIRE(c2.get_theta64() == theta_before);
+
+  // case 3: ordered and trimmed
+  compact_theta_sketch c3 = update_sketch.compact(true, true);
+  REQUIRE(c3.is_ordered());
+  REQUIRE(c3.get_num_retained() == k);
+  REQUIRE(c3.get_theta64() < theta_before); // new theta is the k-th smallest hash
+  REQUIRE(c3.get_theta64() == expected.get_theta64());
+  REQUIRE(std::is_sorted(c3.begin(), c3.end()));
+  REQUIRE(std::vector<uint64_t>(c3.begin(), c3.end()) == expected_entries);
+  // every retained hash is strictly below the new theta
+  for (auto h: c3) REQUIRE(h < c3.get_theta64());
+
+  // case 4: unordered and trimmed: same set and theta, no sort
+  compact_theta_sketch c4 = update_sketch.compact(false, true);
+  REQUIRE_FALSE(c4.is_ordered());
+  REQUIRE(c4.get_num_retained() == k);
+  REQUIRE(c4.get_theta64() == expected.get_theta64());
+  std::vector<uint64_t> c4_entries(c4.begin(), c4.end());
+  std::sort(c4_entries.begin(), c4_entries.end());
+  REQUIRE(c4_entries == expected_entries);
+
+  // the source sketch must be untouched by any of the four
+  REQUIRE(update_sketch.get_num_retained() == retained_before);
+  REQUIRE(update_sketch.get_theta64() == theta_before);
+}
+
+TEST_CASE("theta sketch: compact with trim widens the bounds in estimation mode", "[theta_sketch]") {
+  // trimming is lossy even when the source is already estimating: it discards
+  // retained entries, and the relative error scales with 1 / sqrt(retained)
+  const uint32_t k = 1 << theta_constants::DEFAULT_LG_K;
+  update_theta_sketch sketch = update_theta_sketch::builder().build();
+  for (int i = 0; i < 40000; i++) sketch.update(i);
+  REQUIRE(sketch.is_estimation_mode());
+  REQUIRE(sketch.get_num_retained() > k);
+
+  compact_theta_sketch plain = sketch.compact(true, false);
+  compact_theta_sketch trimmed = sketch.compact(true, true);
+  REQUIRE(trimmed.get_num_retained() == k);
+  REQUIRE(plain.get_num_retained() > trimmed.get_num_retained());
+
+  // fewer retained entries -> strictly wider confidence interval
+  const double plain_width = plain.get_upper_bound(2) - plain.get_lower_bound(2);
+  const double trimmed_width = trimmed.get_upper_bound(2) - trimmed.get_lower_bound(2);
+  REQUIRE(trimmed_width > plain_width);
+}
+
+TEST_CASE("theta sketch: compact with trim converts exact mode to estimation", "[theta_sketch]") {
+  // an update sketch can retain far more than k entries while still in exact mode:
+  // nothing has been evicted yet, so theta is still 1.0 and the count is exact
+  const uint32_t k = 1 << theta_constants::DEFAULT_LG_K;
+  update_theta_sketch sketch = update_theta_sketch::builder().build();
+  const int n = 5000;
+  for (int i = 0; i < n; i++) sketch.update(i);
+  REQUIRE(sketch.get_num_retained() > k);
+  REQUIRE_FALSE(sketch.is_estimation_mode());
+  REQUIRE(sketch.get_theta() == 1.0);
+
+  // not trimming keeps every entry and the exact count
+  compact_theta_sketch exact = sketch.compact(true, false);
+  REQUIRE_FALSE(exact.is_estimation_mode());
+  REQUIRE(exact.get_num_retained() == static_cast<uint32_t>(n));
+  REQUIRE(exact.get_estimate() == Approx(n));
+
+  // trimming is lossy: it discards real data, lowers theta below 1.0 and the
+  // result is an estimate carrying error where the source held an exact count
+  compact_theta_sketch trimmed = sketch.compact(true, true);
+  REQUIRE(trimmed.is_estimation_mode());
+  REQUIRE(trimmed.get_num_retained() == k);
+  REQUIRE(trimmed.get_theta() < 1.0);
+  REQUIRE(trimmed.get_estimate() != Approx(n));
+  // the estimate is still sound: n must lie inside the 3-sigma bounds
+  REQUIRE(trimmed.get_lower_bound(3) <= n);
+  REQUIRE(trimmed.get_upper_bound(3) >= n);
+}
+
+TEST_CASE("theta sketch: compact with trim, empty and below k", "[theta_sketch]") {
+  // empty: trimming changes nothing
+  update_theta_sketch empty_sketch = update_theta_sketch::builder().build();
+  compact_theta_sketch empty_result = empty_sketch.compact(true, true);
+  REQUIRE(empty_result.is_empty());
+  REQUIRE(empty_result.get_num_retained() == 0);
+  REQUIRE(empty_result.is_ordered());
+
+  // below k: nothing to trim, theta and entries are preserved
+  update_theta_sketch small = update_theta_sketch::builder().build();
+  for (int i = 0; i < 100; i++) small.update(i);
+  REQUIRE_FALSE(small.is_estimation_mode());
+
+  compact_theta_sketch small_result = small.compact(true, true);
+  REQUIRE_FALSE(small_result.is_estimation_mode());
+  REQUIRE(small_result.get_num_retained() == 100);
+  REQUIRE(small_result.get_theta64() == small.get_theta64());
+  REQUIRE(small_result.get_estimate() == Approx(100.0));
+  REQUIRE(std::is_sorted(small_result.begin(), small_result.end()));
+  REQUIRE_FALSE(small.compact(false, true).is_ordered());
 }
 
 TEST_CASE("theta sketch: resize exact", "[theta_sketch]") {


### PR DESCRIPTION
## What changed

Adds an optional second flag to the existing `compact()` on `update_theta_sketch_alloc`:

```cpp
compact_theta_sketch_alloc<Allocator> compact(bool ordered = true, bool trim = false) const;
```

`trim = true` reduces the returned sketch to at most the nominal size `k`. The default is unchanged, and because the parameter is defaulted and `compact()` is not virtual here, every existing call site compiles untouched.

Thanks to @stojkomilos for raising the underlying need in #515. This takes a different approach — a flag on the existing method rather than a new `get_result()` — for two reasons: it avoids adding public API surface, and trimming turns out to be lossy enough that it should be an explicit opt-in rather than the natural way to obtain a result.

## Why trimming is opt-in

Relative error scales with `1 / sqrt(retained)`, so discarding entries always widens the confidence bounds, whatever mode the source is in. Measured at the default `lg_k`, comparing `compact()` against `compact(true, true)`:

|      n | retained | 2-sigma width | trimmed width | widened |
|-------:|---------:|--------------:|--------------:|--------:|
|  20000 |     5644 |        895.13 |       1120.26 |   1.25x |
|  40000 |     6037 |       1900.72 |       2419.57 |   1.27x |
|  60000 |     4800 |       3331.83 |       3585.58 |   1.08x |
| 100000 |     4285 |       5873.90 |       6024.14 |   1.03x |

The cost depends on where in the rebuild cycle the sketch is caught, which a caller cannot predict. Worst case is bounded: a sketch grown to just under the `15/16 * 2k` rebuild threshold loses nearly half its entries, widening the bounds by about `sqrt(15/8)`, roughly 37%.

Separately, a sketch in **exact mode** can retain more than `k` entries — nothing has been evicted, so theta is still 1.0. Trimming there discards real data and returns an estimating sketch:

```
n=5000  k=4096  retained=5000  source exact=YES
  compact()            -> estimate 5000     exact=YES
  compact(true, true)  -> estimate 4983.64  exact=no
```

Both effects are documented on the `trim` parameter and pinned by tests.

## Implementation

The trim path copies the retained entries first — the method is `const`, and quick select would permute the live table — then delegates to the shared `trim_to_nominal` helper described below, which partitions with `std::nth_element` at 0-based index `k` so that `entries[k]` becomes the new theta and the `k` entries below it are kept. Sorting happens only when an ordered result is requested. This is the same pivot convention already used by `rebuild()` in `theta_update_sketch_base_impl.hpp`, so trimming and rebuilding cannot drift apart.

## Review follow-up: one shared trim

@proost asked whether there was a reason not to call `shrink_to_fit` here, the way `theta_union_base::get_result` does. There was not — it was an omission. Rather than patch it, `e13672e` removes the cause: the two were copies of one algorithm and the newer copy had already drifted, so the algorithm now lives once, as `trim_to_nominal` in `theta_helpers.hpp`, and both sites call it.

| | before | after |
|---|---|---|
| `theta_union_base::get_result` | 5-line inline kernel | `theta = trim_to_nominal<EK>(entries, nominal_num, theta);` |
| `update_theta_sketch::compact` | 5-line inline kernel, **no `shrink_to_fit`** | `theta = trim_to_nominal<trivial_extract_key>(entries, nominal_size, theta);` |

The missing shrink mattered most exactly where it was missing. An update sketch retains up to `15/16 * 2k` entries between rebuilds, and the entries vector is reserved to that count before being erased down to `k`, so `std::move` handed the compact sketch the untrimmed allocation. Measured at `lg_k=12`: 7674 retained against 4096 kept, holding 1.87x the memory it reports, with 46.6% of the allocation dead. Since a bounded result is the entire point of `trim`, the caller was paying the accuracy cost documented above without getting the size back.

`theta_union_base` is instantiated by both `theta_union` and `tuple_union`, so all three paths now run identical code. Theta's `compact` is the degenerate case, where the entry is the key and `ExtractKey` is `trivial_extract_key`; tuple's entry is a `std::pair<uint64_t, Summary>` and its `pair_extract_key` recovers the hash, which is why one implementation serves both without the summary columns ever being touched.

The invariant is now stated once, in the one place it lives:

> The entry at index `nominal_size` becomes the new theta and is itself discarded, so every entry kept is strictly below the returned value. That is what keeps the estimator unbiased: theta must be an exclusive upper bound on the retained hashes. Getting this off by one does not fail loudly, it quietly biases every estimate the sketch produces.

The extraction is behaviour-preserving, verified rather than assumed: serialized bytes of both the trimmed compact result and the union result are identical before and after, across ordered and unordered at 5000, 26989 and 40000 updates. 26989 is the worst case for retained entries at this `lg_k`.

## How tested

New cases in `theta/test/theta_sketch_test.cpp`:

- **all four ordered/trim combinations**, including that the source sketch is unmodified afterwards, that trimmed output matches `trim()` + `compact()` on theta and retained set, and that every retained hash is strictly below the new theta
- **exact to estimation conversion** at n=5000
- **bounds widening** for a source already in estimation mode
- **empty and below-k** sketches, where trimming is a no-op

```
./build/theta/test/theta_test
All tests passed (20250056 assertions in 89 test cases)

./build/tuple/test/tuple_test          # shares theta_union_base
All tests passed (126786 assertions in 55 test cases)

ctest --test-dir build
100% tests passed, 0 tests failed out of 17
```

## Not included: the same flag on `update_tuple_sketch`

After this PR three of the four theta/tuple result paths can trim and one cannot:

| | trims? |
|---|---|
| `update_theta_sketch_alloc::compact(ordered, trim)` | yes, added here |
| `theta_union::get_result(ordered)` | yes, always — trimming to `k` is required of a union |
| `tuple_union::get_result(ordered)` | yes, always, via the shared `theta_union_base` |
| `update_tuple_sketch::compact(ordered)` | **no** |

The omission is deliberate rather than overlooked. Mechanically the port is small now that `trim_to_nominal` is generic over `ExtractKey`: tuple would pass `pair_extract_key<uint64_t, Summary>`, and `compact_tuple_sketch` already has the constructor the trim path needs (`tuple_sketch.hpp:650`).

What makes it a separate decision is cost, not mechanism. Tuple's `Entry` is `std::pair<uint64_t, Summary>` where theta's is a bare `uint64_t`. The trim path has to copy the retained entries before partitioning, because `compact()` is `const` and quick select permutes what it touches — so for tuple that means copying up to `15/16 * 2k` user-defined `Summary` objects of unknown expense, where theta copies 8-byte hashes. `update_tuple_sketch::compact()` is currently a one-line delegation to a constructor (`tuple_sketch_impl.hpp:257-259`) and never materialises a vector at all, so adding trim changes its cost profile. Whether to accept that copy, or offer a non-const variant that trims in place, deserves its own discussion rather than riding along here.

## Note on the Java side

`datasketches-java` should get the same capability, but it cannot use the same mechanism: `ThetaSketch.compact(boolean dstOrdered, MemorySegment dstSeg)` is `abstract` and already occupies the two-argument slot, so Java needs an overload rather than an added parameter, and `compact(true, null)` would be ambiguous. Also worth care there: `QuickSelect.selectExcludingZeros` is 1-based while `std::nth_element` is 0-based, so the Java port should assert `retained == k` the way these tests do. That work is deliberately left to a separate PR, and it inherits the same gap described above: Java's `UpdatableSketch` needs the capability as much as `UpdateSketch` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


